### PR TITLE
Update ROS 2 docs link and add space between 'ROS' & '1/2'

### DIFF
--- a/doc/differences_to_ros1/differences_to_ros1.rst
+++ b/doc/differences_to_ros1/differences_to_ros1.rst
@@ -53,7 +53,7 @@ RobotHardware to Components
       This usually includes changing the hardware state to receive commands or set it into a safe state before interrupting the command stream.
       It can also include starting and stopping communication.
    #. Implement ``read()`` and ``write()`` methods to exchange commands with the hardware.
-      This method is equivalent to those from ``RobotHW``-class in ROS1.
+      This method is equivalent to those from ``RobotHW``-class in ROS 1.
    #. Do not forget the ``PLUGINLIB_EXPORT_CLASS`` macro at the end of the .cpp file.
 #. Create .xml library description for the pluginlib, for example see `RRBotSystemPositionOnlyHardware <https://github.com/ros-controls/ros2_control_demos/blob/master/ros2_control_demo_hardware/ros2_control_demo_hardware.xml>`_.
 

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -3,7 +3,7 @@
 Getting Started
 ===============
 
-The ros2_control framework is released for ROS2 Foxy.
+The ros2_control framework is released for ROS 2 Foxy.
 To use it, you have to install ``ros-foxy-ros2-control`` and ``ros-foxy-ros2-controllers`` packages.
 Other dependencies are installed automatically.
 
@@ -102,7 +102,7 @@ Hardware Description in URDF
 The ros2_control framework uses the ``<ros2_control>``-tag in the robot's URDF file to describe its components, i.e., the hardware setup.
 The chosen structure enables tracking together multiple `xacro`-macros into one without any changes.
 The example hereunder shows a position-controlled robot with 2-DOF (RRBot), an external 1-DOF force-torque sensor, and an externally controlled 1-DOF parallel gripper as its end-effector.
-For more examples and detailed explanations, check `ros2_control_demos`_ repository and `ROS2 Control Components URDF Examples design document`_.
+For more examples and detailed explanations, check `ros2_control_demos`_ repository and `ROS 2 Control Components URDF Examples design document`_.
 
 .. code:: xml
 
@@ -188,7 +188,7 @@ The example files can be found in the `ros2_control_demos`_ repository.
 .. _Node Lifecycle Design: https://design.ros2.org/articles/node_lifecycle.html
 .. _ros2controlcli: https://github.com/ros-controls/ros2_control/tree/master/ros2controlcli
 .. _Hardware Access through Controllers design document: https://github.com/ros-controls/roadmap/blob/master/design_drafts/hardware_access.md
-.. _ROS2 Control Components URDF Examples design document: https://github.com/ros-controls/roadmap/blob/master/design_drafts/components_architecture_and_urdf_examples.md
+.. _ROS 2 Control Components URDF Examples design document: https://github.com/ros-controls/roadmap/blob/master/design_drafts/components_architecture_and_urdf_examples.md
 .. _roadmap: https://github.com/ros-controls/roadmap
 .. _ROS Discourse: https://discourse.ros.org
 

--- a/doc/project_ideas.rst
+++ b/doc/project_ideas.rst
@@ -62,7 +62,7 @@ Related design drafts:
 | Skills required/preferred:
 
 - Good C++ skills
-- Basic understanding of ROS and/or ROS2
+- Basic understanding of ROS and/or ROS 2
 - Familiarity with the Gazebo simulator
 
 | Possible mentors: Denis Štogl
@@ -94,7 +94,7 @@ The main functionalities for the components and goals of the project are:
 | Skills required/preferred:
 
 - Good C++ skills
-- Basic understanding of ROS and/or ROS2
+- Basic understanding of ROS and/or ROS 2
 
 | Possible mentors: Bence Magyar, Denis Štogl
 | Expected size of project: 350 hours
@@ -122,7 +122,7 @@ Related design document and code implementations:
 | Skills required/preferred:
 
 - Good C++ skills
-- Basic understanding of ROS and/or ROS2
+- Basic understanding of ROS and/or ROS 2
 - Basic understanding of the Gazebo simulator
 
 | Possible mentors: Bence Magyar, Denis Štogl
@@ -134,10 +134,10 @@ Related design document and code implementations:
 Feature-parity for controllers from ROS1
 ----------------------------------------
 
-The ros2_control framework in ROS2 is a rewrite of the ros_control framework from ROS1.
-Our rich set of standard controllers was one of the main motivations for users to adopt ros_control in ROS1 and while we ported most of them, there are quite a few features missing for the two main controllers of this set, the diff_drive_controller and the joint_trajectory_controller.
+The ros2_control framework in ROS 2 is a rewrite of the ros_control framework from ROS 1.
+Our rich set of standard controllers was one of the main motivations for users to adopt ros_control in ROS 1 and while we ported most of them, there are quite a few features missing for the two main controllers of this set, the diff_drive_controller and the joint_trajectory_controller.
 
-This work will consist of reviewing the two versions of the two controllers and comparing for feature parity. Once the missing parts are identified, port them over from ROS1 with as much test support as possible.
+This work will consist of reviewing the two versions of the two controllers and comparing for feature parity. Once the missing parts are identified, port them over from ROS 1 with as much test support as possible.
 
 Related existing issues are:
 
@@ -154,7 +154,7 @@ Stretch goals:
 | Skills required/preferred:
 
 - Good C++ skills
-- Basic understanding of ROS and/or ROS2
+- Basic understanding of ROS and/or ROS 2
 - Basic understanding of unit testing with gmock
 
 | Possible mentors: Bence Magyar

--- a/index.rst
+++ b/index.rst
@@ -18,7 +18,7 @@ Welcome to the ros2_control documentation!
    doc/project_ideas.rst
    doc/acknowledgements/acknowledgements.rst
 
-The ros2_control is a framework for (real-time) control of robots using (`ROS2 <https://index.ros.org/doc/ros2/>`_).
+The ros2_control is a framework for (real-time) control of robots using (`ROS 2 <https://docs.ros.org/en/rolling/>`_).
 Its packages are a rewrite of `ros_control <http://wiki.ros.org/ros_control>`_ packages used in `ROS` (`Robot Operating System <https://wiki.ros.org>`_).
 ros2_control's goal is to simplify integrating new hardware and overcome some drawbacks.
 


### PR DESCRIPTION
To avoid breaking any links, I didn't change any page or section titles.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>