### PR TITLE
[supported_robots] Adding odri hardware interface repository

### DIFF
--- a/doc/supported_robots/supported_robots.rst
+++ b/doc/supported_robots/supported_robots.rst
@@ -22,7 +22,8 @@ Non robot-devices:
 
 * `Force Dimension haptic devices <https://github.com/ICube-Robotics/forcedimension_ros2>`_
 * `ODrive Motor Controller <https://github.com/Factor-Robotics/odrive_ros2_control>`_
-
+* `ODRI Motor Controller <https://github.com/stack-of-tasks/ros2_hardware_interface_odri>`_
+  
 Mobile manipulators:
 
 * `Hello Robot - Stretch (for simple simulation with MoveIt2) <https://github.com/hello-robot/stretch_ros2/blob/galactic/stretch_moveit_config/README.md>`_


### PR DESCRIPTION
This PR adds the link towards the [ODRI](https://open-dynamic-robot-initiative.github.io/) hardware interface repository.

The repository is using multiple interface and illustrates how to create a simple system hardware interface from a DIY robot.

Tested for position on the [Bolt robot](https://www.youtube.com/watch?v=x2jYQdjT_es).

The [ros2_control_bolt](https://github.com/stack-of-tasks/ros2_control_bolt) repository will be linked in a different PR.
