### PR TITLE
Add igus to list of supported robot manufacturers

### DIFF
--- a/doc/supported_robots/supported_robots.rst
+++ b/doc/supported_robots/supported_robots.rst
@@ -9,6 +9,7 @@ Official (supported by robot manufacturer):
 * `Universal Robots <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver>`_
 * `Franka Emika research robots <https://github.com/frankaemika/franka_ros2>`_
 * `xArm <https://github.com/xarm-Developer/xarm_ros2>`_
+* `igus/Commonplace Robotics <https://github.com/CommonplaceRobotics/iRC_ROS>`_
 
 Unofficial (from the community):
 


### PR DESCRIPTION
Hello everyone,

In the last months I did an internship and during that time developed a ROS 2 package for igus robots, primarily the igus ReBeL.

As the hardware interfacing is done with ros2_control I would like to add the package to the list of officially supported robots.
Regarding the name of the manufacturer, igus Low Cost Automation manufactures the robots but we at CPR, an igus subsidy, manufacture the electronics and software, so I opted to add both company names. I'm open to changing this though.

Lastly the package is still in development, as such any input from the community is also greatly appreciated.
