### PR TITLE
Sphinx extension for autodocs

### DIFF
--- a/.github/workflows/sphinx-make-page.yml
+++ b/.github/workflows/sphinx-make-page.yml
@@ -26,6 +26,7 @@ jobs:
         pip install --upgrade --requirement requirements.txt
     - name: Install generator parameter library
       run: |
+        cd
         git clone https://github.com/PickNikRobotics/generate_parameter_library.git
         cd generate_parameter_library/generate_parameter_library_py/
         sudo python setup.py install

--- a/.github/workflows/sphinx-make-page.yml
+++ b/.github/workflows/sphinx-make-page.yml
@@ -24,6 +24,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade --requirement requirements.txt
+    - name: Install generator parameter library
+      run: |
+        git clone https://github.com/PickNikRobotics/generate_parameter_library.git
+        cd generate_parameter_library/generate_parameter_library_py/
+        sudo python setup.py install
     - name: Install doxygen and graphviz
       run: sudo apt-get install -y doxygen graphviz
     - name: Build multiversion with API

--- a/_ext/generate_parameter_library.py
+++ b/_ext/generate_parameter_library.py
@@ -1,5 +1,5 @@
 from docutils import nodes
-from docutils.parsers.rst import Directive
+from sphinx.util.docutils import SphinxDirective
 from sphinx.util.nodes import nested_parse_with_titles
 from docutils.statemachine import ViewList
 from generate_parameter_library_py.parse_yaml import (
@@ -10,14 +10,14 @@ from generate_parameter_library_py.generate_markdown import (
     ParameterDetailMarkdown
 )
 
-class GeneraterParameterLibraryDetails(Directive):
+class GeneraterParameterLibraryDetails(SphinxDirective):
     required_arguments = 1
     optional_arguments = 0
 
     def run(self):
-        yaml_file = self.arguments[0]
-        # cpp is used here because it the desired style of the markdown,
-        # e.g. "false" for C++ instead of "False" for Python
+        # get the absolute path from sphinx tree
+        yaml_file = self.env.relfn2path(self.arguments[0], self.env.docname)[0]
+
         gen_param_struct = GenerateCode("rst")
         gen_param_struct.parse(yaml_file, "")
 
@@ -43,14 +43,14 @@ class GeneraterParameterLibraryDetails(Directive):
 
         return node.children
 
-class GeneraterParameterLibraryDefaultConfig(Directive):
+class GeneraterParameterLibraryDefaultConfig(SphinxDirective):
     required_arguments = 1
     optional_arguments = 0
 
     def run(self):
-        yaml_file = self.arguments[0]
-        # cpp is used here because it the desired style of the markdown,
-        # e.g. "false" for C++ instead of "False" for Python
+        # get the absolute path from sphinx tree
+        yaml_file = self.env.relfn2path(self.arguments[0], self.env.docname)[0]
+
         gen_param_struct = GenerateCode("rst")
         gen_param_struct.parse(yaml_file, "")
         auto_doc = DefaultConfigMarkdown(gen_param_struct)

--- a/_ext/generate_parameter_library.py
+++ b/_ext/generate_parameter_library.py
@@ -18,7 +18,7 @@ class GeneraterParameterLibraryDetails(Directive):
         yaml_file = self.arguments[0]
         # cpp is used here because it the desired style of the markdown,
         # e.g. "false" for C++ instead of "False" for Python
-        gen_param_struct = GenerateCode("cpp")
+        gen_param_struct = GenerateCode("rst")
         gen_param_struct.parse(yaml_file, "")
 
         param_details = [
@@ -51,7 +51,7 @@ class GeneraterParameterLibraryDefaultConfig(Directive):
         yaml_file = self.arguments[0]
         # cpp is used here because it the desired style of the markdown,
         # e.g. "false" for C++ instead of "False" for Python
-        gen_param_struct = GenerateCode("cpp")
+        gen_param_struct = GenerateCode("rst")
         gen_param_struct.parse(yaml_file, "")
         auto_doc = DefaultConfigMarkdown(gen_param_struct)
         docs = str(auto_doc)

--- a/_ext/generate_parameter_library.py
+++ b/_ext/generate_parameter_library.py
@@ -1,0 +1,83 @@
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from sphinx.util.nodes import nested_parse_with_titles
+from docutils.statemachine import ViewList
+from generate_parameter_library_py.parse_yaml import (
+    GenerateCode,
+)
+from generate_parameter_library_py.generate_markdown import (
+    DefaultConfigMarkdown,
+    ParameterDetailMarkdown
+)
+
+class GeneraterParameterLibraryDetails(Directive):
+    required_arguments = 1
+    optional_arguments = 0
+
+    def run(self):
+        yaml_file = self.arguments[0]
+        # cpp is used here because it the desired style of the markdown,
+        # e.g. "false" for C++ instead of "False" for Python
+        gen_param_struct = GenerateCode("cpp")
+        gen_param_struct.parse(yaml_file, "")
+
+        param_details = [
+            ParameterDetailMarkdown(param)
+            for param in gen_param_struct.declare_parameters
+        ]
+        docs = "\n".join(str(val) for val in param_details)
+        # print(docs)
+
+        # Add the content one line at a time.
+        # Second argument is the filename to report in any warnings
+        # or errors, third argument is the line number.
+        # rst.append(docs, yaml_file, 10)
+        rst = ViewList()
+        for line in docs.splitlines():
+          rst.append(line, yaml_file)
+
+        node = nodes.section()
+        # necessary so that the child nodes get the right source/line set
+        node.document = self.state.document
+        nested_parse_with_titles(self.state, rst, node)
+
+        return node.children
+
+class GeneraterParameterLibraryDefaultConfig(Directive):
+    required_arguments = 1
+    optional_arguments = 0
+
+    def run(self):
+        yaml_file = self.arguments[0]
+        # cpp is used here because it the desired style of the markdown,
+        # e.g. "false" for C++ instead of "False" for Python
+        gen_param_struct = GenerateCode("cpp")
+        gen_param_struct.parse(yaml_file, "")
+        auto_doc = DefaultConfigMarkdown(gen_param_struct)
+        docs = str(auto_doc)
+        # print(docs)
+
+        # Add the content one line at a time.
+        # Second argument is the filename to report in any warnings
+        # or errors, third argument is the line number.
+        # rst.append(docs, yaml_file, 10)
+        rst = ViewList()
+        for line in docs.splitlines():
+          rst.append(line, yaml_file)
+
+        node = nodes.section()
+        # necessary so that the child nodes get the right source/line set
+        node.document = self.state.document
+        nested_parse_with_titles(self.state, rst, node)
+
+        return node.children
+
+def setup(app):
+    app.add_directive("generate_parameter_library_details", GeneraterParameterLibraryDetails)
+    app.add_directive("generate_parameter_library_default", GeneraterParameterLibraryDefaultConfig)
+
+    return {
+        'version': '0.1',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/conf.py
+++ b/conf.py
@@ -19,6 +19,7 @@ import time
 
 from docutils.parsers.rst import Directive
 
+sys.path.append(os.path.abspath("./_ext"))
 sys.path.append(os.path.abspath("./sphinx-multiversion"))
 
 # -- General configuration -------------------------------------------------
@@ -83,6 +84,7 @@ extensions = [
     "sphinx_multiversion",
     "sphinx_copybutton",
     "sphinxcontrib.globalsubs"
+    "generate_parameter_library"
 ]
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.

--- a/conf.py
+++ b/conf.py
@@ -83,7 +83,7 @@ extensions = [
     "sphinx_rtd_theme",
     "sphinx_multiversion",
     "sphinx_copybutton",
-    "sphinxcontrib.globalsubs"
+    "sphinxcontrib.globalsubs",
     "generate_parameter_library"
 ]
 


### PR DESCRIPTION
I created a sphinx extension, which uses the python scripts of the `generate_parameter_library` to create parameter documentation automatically.

It can be configured in any rst file by adding the directive

```rst
.. generate_parameter_library_details:: ../src/admittance_controller_parameters.yaml
```
for a detailed parameter list and

```rst
.. generate_parameter_library_default:: ../src/admittance_controller_parameters.yaml

```
for a default ros-params yaml file.

An example with the current rst template
![image](https://github.com/ros-controls/control.ros.org/assets/3367244/2b876e97-b5a8-4601-b883-6deca35c6bba)


Open tasks:
- [x] https://github.com/PickNikRobotics/generate_parameter_library/pull/119
- [ ] implement __map_ https://github.com/PickNikRobotics/generate_parameter_library/issues/118
- [x] install the library within the github workflow, via pip or manually?
- [x] use local paths instead of global ones starting with `doc/`