### PR TITLE
Mark galactic + foxy EOL

### DIFF
--- a/_templates/versions.html
+++ b/_templates/versions.html
@@ -7,13 +7,13 @@
   </span>
   <div class="rst-other-versions">
     <dl>
-      <dt>ros2_control - Rolling</dt>
+      <dt>In Development</dt>
       {%- for item in versions.in_development|sort(reverse=True) %}
       <dd><a href="{{ item.url }}">{{ item.name|title }} (latest)</a></dd>
       {%- endfor %}
     </dl>
     <dl>
-      <dt>ros2_control - Foxy, Galactic, and Humble</dt>
+      <dt>Releases</dt>
       {%- for item in versions.releases|sort(reverse=True) %}
         {%- if item.name == latest_version.name %}
         <dd><a href="{{ item.url }}">{{ item.name|title }} (recommended)</a></dd><br>

--- a/conf.py
+++ b/conf.py
@@ -170,7 +170,7 @@ smv_branch_whitelist = r"^(foxy|galactic|humble|master)$"
 smv_released_pattern = r"^refs/(heads|remotes/[^/]+)/(foxy|galactic|humble).*$"
 smv_remote_whitelist = r"^(origin)$"
 smv_latest_version = "humble"
-smv_eol_versions = []
+smv_eol_versions = ["foxy", "galactic"]
 
 distro_full_names = {
     "foxy": "Foxy Fitzroy",


### PR DESCRIPTION
This adds EOL comment to galactic + foxy branches in the multi-version menu.

I also used the headings from docs.ros.org