### PR TITLE
Common repos file

### DIFF
--- a/.github/workflows/humble-binary-build-main.yml
+++ b/.github/workflows/humble-binary-build-main.yml
@@ -6,9 +6,6 @@ on:
   workflow_dispatch:
     branches:
       - master
-  push:
-    branches:
-      - common_repos_file
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/humble-binary-build-main.yml
+++ b/.github/workflows/humble-binary-build-main.yml
@@ -1,0 +1,23 @@
+name: Humble Binary Build - main
+# author: Denis Štogl <denis@stoglrobotics.de>
+# description: 'Build & test all dependencies from released (binary) packages.'
+
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  push:
+    branches:
+      - common_repos_file
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '03 1 * * *'
+
+jobs:
+  binary:
+    uses: ./.github/workflows/reusable-industrial-ci-with-cache.yml
+    with:
+      ros_distro: humble
+      ros_repo: main
+      upstream_workspace: ros_controls.humble.repos
+      ref_for_scheduled_build: master

--- a/.github/workflows/humble-binary-build-main.yml
+++ b/.github/workflows/humble-binary-build-main.yml
@@ -19,5 +19,5 @@ jobs:
     with:
       ros_distro: humble
       ros_repo: main
-      upstream_workspace: ros_controls.humble.repos
+      target_workspace: ros_controls.humble.repos
       ref_for_scheduled_build: master

--- a/.github/workflows/humble-binary-build-testing.yml
+++ b/.github/workflows/humble-binary-build-testing.yml
@@ -6,6 +6,9 @@ on:
   workflow_dispatch:
     branches:
       - master
+  push:
+    branches:
+      - common_repos_file
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/humble-binary-build-testing.yml
+++ b/.github/workflows/humble-binary-build-testing.yml
@@ -1,0 +1,20 @@
+name: Humble Binary Build - testing
+# author: Denis Štogl <denis@stoglrobotics.de>
+# description: 'Build & test all dependencies from released (binary) packages.'
+
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '03 1 * * *'
+
+jobs:
+  binary:
+    uses: ./.github/workflows/reusable-industrial-ci-with-cache.yml
+    with:
+      ros_distro: humble
+      ros_repo: testing
+      upstream_workspace: ros_controls.humble.repos
+      ref_for_scheduled_build: master

--- a/.github/workflows/humble-binary-build-testing.yml
+++ b/.github/workflows/humble-binary-build-testing.yml
@@ -6,9 +6,6 @@ on:
   workflow_dispatch:
     branches:
       - master
-  push:
-    branches:
-      - common_repos_file
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/humble-binary-build-testing.yml
+++ b/.github/workflows/humble-binary-build-testing.yml
@@ -16,5 +16,5 @@ jobs:
     with:
       ros_distro: humble
       ros_repo: testing
-      upstream_workspace: ros_controls.humble.repos
+      target_workspace: ros_controls.humble.repos
       ref_for_scheduled_build: master

--- a/.github/workflows/iron-binary-build-main.yml
+++ b/.github/workflows/iron-binary-build-main.yml
@@ -19,5 +19,5 @@ jobs:
     with:
       ros_distro: iron
       ros_repo: main
-      upstream_workspace: ros_controls.iron.repos
+      target_workspace: ros_controls.iron.repos
       ref_for_scheduled_build: master

--- a/.github/workflows/iron-binary-build-main.yml
+++ b/.github/workflows/iron-binary-build-main.yml
@@ -6,9 +6,6 @@ on:
   workflow_dispatch:
     branches:
       - master
-  push:
-    branches:
-      - common_repos_file
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/iron-binary-build-main.yml
+++ b/.github/workflows/iron-binary-build-main.yml
@@ -1,0 +1,23 @@
+name: Iron Binary Build - main
+# author: Denis Štogl <denis@stoglrobotics.de>
+# description: 'Build & test all dependencies from released (binary) packages.'
+
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  push:
+    branches:
+      - common_repos_file
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '03 1 * * *'
+
+jobs:
+  binary:
+    uses: ./.github/workflows/reusable-industrial-ci-with-cache.yml
+    with:
+      ros_distro: iron
+      ros_repo: main
+      upstream_workspace: ros_controls.iron.repos
+      ref_for_scheduled_build: master

--- a/.github/workflows/iron-binary-build-testing.yml
+++ b/.github/workflows/iron-binary-build-testing.yml
@@ -6,6 +6,9 @@ on:
   workflow_dispatch:
     branches:
       - master
+  push:
+    branches:
+      - common_repos_file
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/iron-binary-build-testing.yml
+++ b/.github/workflows/iron-binary-build-testing.yml
@@ -16,5 +16,5 @@ jobs:
     with:
       ros_distro: iron
       ros_repo: testing
-      upstream_workspace: ros_controls.iron.repos
+      target_workspace: ros_controls.iron.repos
       ref_for_scheduled_build: master

--- a/.github/workflows/iron-binary-build-testing.yml
+++ b/.github/workflows/iron-binary-build-testing.yml
@@ -6,9 +6,6 @@ on:
   workflow_dispatch:
     branches:
       - master
-  push:
-    branches:
-      - common_repos_file
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/iron-binary-build-testing.yml
+++ b/.github/workflows/iron-binary-build-testing.yml
@@ -1,0 +1,20 @@
+name: Iron Binary Build - testing
+# author: Denis Štogl <denis@stoglrobotics.de>
+# description: 'Build & test all dependencies from released (binary) packages.'
+
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '03 1 * * *'
+
+jobs:
+  binary:
+    uses: ./.github/workflows/reusable-industrial-ci-with-cache.yml
+    with:
+      ros_distro: iron
+      ros_repo: testing
+      upstream_workspace: ros_controls.iron.repos
+      ref_for_scheduled_build: master

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -1,0 +1,96 @@
+name: Reusable industrial_ci Workflow with Cache
+# Reusable action to simplify dealing with ROS/ROS2 industrial_ci builds with cache
+# author: Denis Štogl <denis@stoglrobotics.de>
+
+on:
+  workflow_call:
+    inputs:
+      ref_for_scheduled_build:
+        description: 'Reference on which the repo should be checkout for scheduled build. Usually is this name of a branch or a tag.'
+        default: ''
+        required: false
+        type: string
+
+      upstream_workspace:
+        description: 'UPSTREAM_WORKSPACE variable for industrial_ci. Usually path to local .repos file.'
+        required: true
+        type: string
+      ros_distro:
+        description: 'ROS_DISTRO variable for industrial_ci'
+        required: true
+        type: string
+      ros_repo:
+        description: 'ROS_REPO to run for industrial_ci. Possible values: "main", "testing"'
+        default: 'main'
+        required: false
+        type: string
+      os_code_name:
+        description: 'OS_CODE_NAME variable for industrial_ci'
+        default: ''
+        required: false
+        type: string
+      before_install_upstream_dependencies:
+        description: 'BEFORE_INSTALL_UPSTREAM_DEPENDENCIES variable for industrial_ci'
+        default: ''
+        required: false
+        type: string
+
+      ccache_dir:
+        description: 'Local path to store cache (from "github.workspace"). For standard industrial_ci configuration do not have to be changed'
+        default: '.ccache'
+        required: false
+        type: string
+      basedir:
+        description: 'Local path to workspace base directory to cache (from "github.workspace"). For standard industrial_ci configuration do not have to be changed'
+        default: '.work'
+        required: false
+        type: string
+
+
+jobs:
+  reusable_industrial_ci_with_cache:
+    name: ${{ inputs.ros_distro }} ${{ inputs.ros_repo }} ${{ inputs.os_code_name }}
+    runs-on: ubuntu-latest
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/${{ inputs.ccache_dir }}
+      BASEDIR: ${{ github.workspace }}/${{ inputs.basedir }}
+      CACHE_PREFIX: ${{ inputs.ros_distro }}-${{ inputs.upstream_workspace }}-${{ inputs.ros_repo }}-${{ github.job }}
+    steps:
+      - name: Checkout ${{ inputs.ref }} when build is not scheduled
+        if: ${{ github.event_name != 'schedule' }}
+        uses: actions/checkout@v3
+      - name: Checkout ${{ inputs.ref }} on scheduled build
+        if: ${{ github.event_name == 'schedule' }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref_for_scheduled_build }}
+      - name: cache target_ws
+        if: ${{ ! matrix.env.CCOV }}
+        uses: pat-s/always-upload-cache@v3.0.11
+        with:
+          path: ${{ env.BASEDIR }}/target_ws
+          key: target_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('**/CMakeLists.txt', '**/package.xml') }}-${{ github.run_id }}
+          restore-keys: |
+            target_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('**/CMakeLists.txt', '**/package.xml') }}
+      - name: cache ccache
+        uses: pat-s/always-upload-cache@v3.0.11
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}-${{ github.run_id }}
+          restore-keys: |
+            ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}
+            ccache-${{ env.CACHE_PREFIX }}
+      - uses: 'ros-industrial/industrial_ci@master'
+        env:
+          UPSTREAM_WORKSPACE: ${{ inputs.upstream_workspace }}
+          ROS_DISTRO: ${{ inputs.ros_distro }}
+          ROS_REPO: ${{ inputs.ros_repo }}
+          OS_CODE_NAME: ${{ inputs.os_code_name }}
+          BEFORE_INSTALL_UPSTREAM_DEPENDENCIES: ${{ inputs.before_install_upstream_dependencies }}
+      - name: prepare target_ws for cache
+        if: ${{ always() && ! matrix.env.CCOV }}
+        run: |
+          du -sh ${{ env.BASEDIR }}/target_ws
+          sudo find ${{ env.BASEDIR }}/target_ws -wholename '*/test_results/*' -delete
+          sudo rm -rf ${{ env.BASEDIR }}/target_ws/src
+          du -sh ${{ env.BASEDIR }}/target_ws

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -35,6 +35,12 @@ on:
         required: false
         type: string
 
+      gz_version:
+        description: 'gz version used to build gz_ros2_control'
+        default: 'fortress'
+        required: false
+        type: string
+
       ccache_dir:
         description: 'Local path to store cache (from "github.workspace"). For standard industrial_ci configuration do not have to be changed'
         default: '.ccache'
@@ -87,6 +93,7 @@ jobs:
           ROS_REPO: ${{ inputs.ros_repo }}
           OS_CODE_NAME: ${{ inputs.os_code_name }}
           BEFORE_INSTALL_TARGET_DEPENDENCIES: ${{ inputs.before_install_target_dependencies }}
+          DOCKER_RUN_OPTS: -e GZ_VERSION=${{ inputs.gz_version }}
       - name: prepare target_ws for cache
         if: ${{ always() && ! matrix.env.CCOV }}
         run: |

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -11,8 +11,8 @@ on:
         required: false
         type: string
 
-      upstream_workspace:
-        description: 'UPSTREAM_WORKSPACE variable for industrial_ci. Usually path to local .repos file.'
+      target_workspace:
+        description: 'TARGET_WORKSPACE variable for industrial_ci. Usually path to local .repos file.'
         required: true
         type: string
       ros_distro:
@@ -29,8 +29,8 @@ on:
         default: ''
         required: false
         type: string
-      before_install_upstream_dependencies:
-        description: 'BEFORE_INSTALL_UPSTREAM_DEPENDENCIES variable for industrial_ci'
+      before_install_target_dependencies:
+        description: 'BEFORE_INSTALL_TARGET_DEPENDENCIES variable for industrial_ci'
         default: ''
         required: false
         type: string
@@ -54,7 +54,7 @@ jobs:
     env:
       CCACHE_DIR: ${{ github.workspace }}/${{ inputs.ccache_dir }}
       BASEDIR: ${{ github.workspace }}/${{ inputs.basedir }}
-      CACHE_PREFIX: ${{ inputs.ros_distro }}-${{ inputs.upstream_workspace }}-${{ inputs.ros_repo }}-${{ github.job }}
+      CACHE_PREFIX: ${{ inputs.ros_distro }}-${{ inputs.target_workspace }}-${{ inputs.ros_repo }}-${{ github.job }}
     steps:
       - name: Checkout ${{ inputs.ref }} when build is not scheduled
         if: ${{ github.event_name != 'schedule' }}
@@ -82,11 +82,11 @@ jobs:
             ccache-${{ env.CACHE_PREFIX }}
       - uses: 'ros-industrial/industrial_ci@master'
         env:
-          UPSTREAM_WORKSPACE: ${{ inputs.upstream_workspace }}
+          TARGET_WORKSPACE: ${{ inputs.target_workspace }}
           ROS_DISTRO: ${{ inputs.ros_distro }}
           ROS_REPO: ${{ inputs.ros_repo }}
           OS_CODE_NAME: ${{ inputs.os_code_name }}
-          BEFORE_INSTALL_UPSTREAM_DEPENDENCIES: ${{ inputs.before_install_upstream_dependencies }}
+          BEFORE_INSTALL_TARGET_DEPENDENCIES: ${{ inputs.before_install_target_dependencies }}
       - name: prepare target_ws for cache
         if: ${{ always() && ! matrix.env.CCOV }}
         run: |

--- a/.github/workflows/rolling-binary-build-main.yml
+++ b/.github/workflows/rolling-binary-build-main.yml
@@ -6,6 +6,9 @@ on:
   workflow_dispatch:
     branches:
       - master
+  push:
+    branches:
+      - common_repos_file
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/rolling-binary-build-main.yml
+++ b/.github/workflows/rolling-binary-build-main.yml
@@ -6,9 +6,6 @@ on:
   workflow_dispatch:
     branches:
       - master
-  push:
-    branches:
-      - common_repos_file
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/rolling-binary-build-main.yml
+++ b/.github/workflows/rolling-binary-build-main.yml
@@ -19,5 +19,5 @@ jobs:
     with:
       ros_distro: rolling
       ros_repo: main
-      upstream_workspace: ros_controls.rolling.repos
+      target_workspace: ros_controls.rolling.repos
       ref_for_scheduled_build: master

--- a/.github/workflows/rolling-binary-build-main.yml
+++ b/.github/workflows/rolling-binary-build-main.yml
@@ -1,0 +1,20 @@
+name: Rolling Binary Build - main
+# author: Denis Štogl <denis@stoglrobotics.de>
+# description: 'Build & test all dependencies from released (binary) packages.'
+
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '03 1 * * *'
+
+jobs:
+  binary:
+    uses: ./.github/workflows/reusable-industrial-ci-with-cache.yml
+    with:
+      ros_distro: rolling
+      ros_repo: main
+      upstream_workspace: ros_controls.rolling.repos
+      ref_for_scheduled_build: master

--- a/.github/workflows/rolling-binary-build-testing.yml
+++ b/.github/workflows/rolling-binary-build-testing.yml
@@ -6,6 +6,9 @@ on:
   workflow_dispatch:
     branches:
       - master
+  push:
+    branches:
+      - common_repos_file
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/rolling-binary-build-testing.yml
+++ b/.github/workflows/rolling-binary-build-testing.yml
@@ -16,5 +16,5 @@ jobs:
     with:
       ros_distro: rolling
       ros_repo: testing
-      upstream_workspace: ros_controls.rolling.repos
+      target_workspace: ros_controls.rolling.repos
       ref_for_scheduled_build: master

--- a/.github/workflows/rolling-binary-build-testing.yml
+++ b/.github/workflows/rolling-binary-build-testing.yml
@@ -6,9 +6,6 @@ on:
   workflow_dispatch:
     branches:
       - master
-  push:
-    branches:
-      - common_repos_file
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/rolling-binary-build-testing.yml
+++ b/.github/workflows/rolling-binary-build-testing.yml
@@ -1,0 +1,20 @@
+name: Rolling Binary Build - testing
+# author: Denis Štogl <denis@stoglrobotics.de>
+# description: 'Build & test all dependencies from released (binary) packages.'
+
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '03 1 * * *'
+
+jobs:
+  binary:
+    uses: ./.github/workflows/reusable-industrial-ci-with-cache.yml
+    with:
+      ros_distro: rolling
+      ros_repo: testing
+      upstream_workspace: ros_controls.rolling.repos
+      ref_for_scheduled_build: master

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -9,18 +9,45 @@ Installation
 
 Binary packages
 ------------------
-The ros2_control framework is released for ROS 2 rolling.
-To use it, you have to install ``ros-rolling-ros2-control`` and ``ros-rolling-ros2-controllers`` packages.
+The ros2_control framework is released for ROS 2 {DISTRO}.
+To use it, you have to install ``ros-{DISTRO}-ros2-control`` and ``ros-{DISTRO}-ros2-controllers`` packages.
 
 Building from Source
 ---------------------------
 
-If you want to install the framework from source, use the following commands in your workspace main folder:
+.. raw:: html
 
-.. code:: bash
+    <a href="https://github.com/ros-controls/control.ros.org/actions/workflows/{DISTRO}-binary-build-main.yml">
+        <img src="https://github.com/ros-controls/control.ros.org/actions/workflows/{DISTRO}g-binary-build-main.yml/badge.svg" alt="{DISTRO} Binary Build - main"/></a>
 
-   wget https://raw.githubusercontent.com/ros-controls/control.ros.org/master/ros_controls.{REPOS_FILE_BRANCH}.repos
-   vcs import src < ros_controls.{REPOS_FILE_BRANCH}.repos
+If you want to install the framework from source, e.g., for contributing to the framework, use the following commands:
+
+* Download all repositories
+
+  .. code-block:: shell
+
+    mkdir -p ~/ros2_ws/src
+    cd ~/ros2_ws/
+    wget https://raw.githubusercontent.com/ros-controls/control.ros.org/master/ros_controls.$ROS_DISTRO.repos
+    vcs import src < ros_controls.$ROS_DISTRO.repos
+
+* Install dependencies:
+
+  .. code-block:: shell
+
+    rosdep update --rosdistro=$ROS_DISTRO
+    sudo apt-get update
+    rosdep install --from-paths src --ignore-src -r -y
+
+* Build everything, e.g. with:
+
+  .. code-block:: shell
+
+    . /opt/ros/${ROS_DISTRO}/setup.sh
+    colcon build --symlink-install
+
+* Do not forget to source ``setup.bash`` from the ``install`` folder!
+
 
 Architecture
 ============

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -19,7 +19,7 @@ If you want to install the framework from source, use the following commands in 
 
 .. code:: bash
 
-   wget https://raw.githubusercontent.com/ros-controls/ros2_control/master/ros2_control.rolling.repos
+   wget https://raw.githubusercontent.com/ros-controls/control.ros.org/master/ros_controls.rolling.repos
    vcs import src < ros2_control.repos
 
 Architecture

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -20,7 +20,7 @@ If you want to install the framework from source, use the following commands in 
 .. code:: bash
 
    wget https://raw.githubusercontent.com/ros-controls/control.ros.org/master/ros_controls.rolling.repos
-   vcs import src < ros2_control.repos
+   vcs import src < ros_controls.rolling.repos
 
 Architecture
 ============

--- a/ros_controls.humble.repos
+++ b/ros_controls.humble.repos
@@ -1,0 +1,37 @@
+repositories:
+  ros-controls/realtime_tools:
+    type: git
+    url: https://github.com/ros-controls/realtime_tools.git
+    version: master
+  ros-controls/control_msgs:
+    type: git
+    url: https://github.com/ros-controls/control_msgs.git
+    version: humble
+  ros-controls/ros2_control:
+    type: git
+    url: https://github.com/ros-controls/ros2_control.git
+    version: humble
+  ros-controls/ros2_controllers:
+    type: git
+    url: https://github.com/ros-controls/ros2_controllers.git
+    version: humble
+  ros-controls/kinematics_interface:
+    type: git
+    url: https://github.com/ros-controls/kinematics_interface.git
+    version: humble
+  ros-controls/gz_ros2_control:
+    type: git
+    url: https://github.com/ros-controls/gz_ros2_control.git
+    version: humble
+  ros-controls/gazebo_ros2_control:
+    type: git
+    url: https://github.com/ros-controls/gazebo_ros2_control.git
+    version: humble
+  ros-controls/ros2_control_demos:
+    type: git
+    url: https://github.com/ros-controls/ros2_control_demos.git
+    version: humble
+  ros-controls/control_toolbox:
+    type: git
+    url: https://github.com/ros-controls/control_toolbox.git
+    version: ros2-master

--- a/ros_controls.humble.repos
+++ b/ros_controls.humble.repos
@@ -18,7 +18,7 @@ repositories:
   ros-controls/kinematics_interface:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git
-    version: humble
+    version: master
   ros-controls/gz_ros2_control:
     type: git
     url: https://github.com/ros-controls/gz_ros2_control.git

--- a/ros_controls.iron.repos
+++ b/ros_controls.iron.repos
@@ -1,0 +1,37 @@
+repositories:
+  ros-controls/realtime_tools:
+    type: git
+    url: https://github.com/ros-controls/realtime_tools.git
+    version: master
+  ros-controls/control_msgs:
+    type: git
+    url: https://github.com/ros-controls/control_msgs.git
+    version: master
+  ros-controls/ros2_control:
+    type: git
+    url: https://github.com/ros-controls/ros2_control.git
+    version: master
+  ros-controls/ros2_controllers:
+    type: git
+    url: https://github.com/ros-controls/ros2_controllers.git
+    version: master
+  ros-controls/kinematics_interface:
+    type: git
+    url: https://github.com/ros-controls/kinematics_interface.git
+    version: master
+  ros-controls/gz_ros2_control:
+    type: git
+    url: https://github.com/ros-controls/gz_ros2_control.git
+    version: master
+  ros-controls/gazebo_ros2_control:
+    type: git
+    url: https://github.com/ros-controls/gazebo_ros2_control.git
+    version: master
+  ros-controls/ros2_control_demos:
+    type: git
+    url: https://github.com/ros-controls/ros2_control_demos.git
+    version: master
+  ros-controls/control_toolbox:
+    type: git
+    url: https://github.com/ros-controls/control_toolbox.git
+    version: ros2-master

--- a/ros_controls.rolling.repos
+++ b/ros_controls.rolling.repos
@@ -1,0 +1,37 @@
+repositories:
+  ros-controls/realtime_tools:
+    type: git
+    url: https://github.com/ros-controls/realtime_tools.git
+    version: master
+  ros-controls/control_msgs:
+    type: git
+    url: https://github.com/ros-controls/control_msgs.git
+    version: master
+  ros-controls/ros2_control:
+    type: git
+    url: https://github.com/ros-controls/ros2_control.git
+    version: master
+  ros-controls/ros2_controllers:
+    type: git
+    url: https://github.com/ros-controls/ros2_controllers.git
+    version: master
+  ros-controls/kinematics_interface:
+    type: git
+    url: https://github.com/ros-controls/kinematics_interface.git
+    version: master
+  ros-controls/gz_ros2_control:
+    type: git
+    url: https://github.com/ros-controls/gz_ros2_control.git
+    version: master
+  ros-controls/gazebo_ros2_control:
+    type: git
+    url: https://github.com/ros-controls/gazebo_ros2_control.git
+    version: master
+  ros-controls/ros2_control_demos:
+    type: git
+    url: https://github.com/ros-controls/ros2_control_demos.git
+    version: master
+  ros-controls/control_toolbox:
+    type: git
+    url: https://github.com/ros-controls/control_toolbox.git
+    version: master

--- a/ros_controls.rolling.repos
+++ b/ros_controls.rolling.repos
@@ -34,4 +34,4 @@ repositories:
   ros-controls/control_toolbox:
     type: git
     url: https://github.com/ros-controls/control_toolbox.git
-    version: master
+    version: ros2-master


### PR DESCRIPTION
This PR adds a common repos file containing the source repos of the whole ros2_control stack. This repos file can be used inside the docs to tell people how to build from source instead of referring to an incomplete one as currently.

Additionally, this PR adds workflow files that will build the complete ros2_control stack from source each night.