### PR TITLE
Update build instructions

### DIFF
--- a/.github/workflows/sphinx-make-page.yml
+++ b/.github/workflows/sphinx-make-page.yml
@@ -29,7 +29,6 @@ jobs:
         cd
         git clone https://github.com/PickNikRobotics/generate_parameter_library.git
         cd generate_parameter_library/generate_parameter_library_py/
-        python -m pip install pyyaml
         python -m pip install .
     - name: Install doxygen and graphviz
       run: sudo apt-get install -y doxygen graphviz

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ There are `make` commands available which automate the process of building and i
 1. If you are running inside a docker container, be sure to open a port so the website can be accessed.
 2. Install doxygen and graphviz: `sudo apt install doxygen graphviz`
 3. `python3 -m pip install -r requirements.txt`
-4. Install generate_parameter_library>0.3.3. If it is not installed as a ROS 2 package already, install it as python package from source
+4. Install generate_parameter_library>0.3.3. If it is not installed as a ROS 2 package already, install it as python module from source
 ```bash
 cd
 git clone https://github.com/PickNikRobotics/generate_parameter_library.git

--- a/README.md
+++ b/README.md
@@ -26,7 +26,14 @@ There are `make` commands available which automate the process of building and i
 1. If you are running inside a docker container, be sure to open a port so the website can be accessed.
 2. Install doxygen and graphviz: `sudo apt install doxygen graphviz`
 3. `python3 -m pip install -r requirements.txt`
-4. Building of the documentation. Depends on what you want to do. See either single version or multiversion below.
+4. Install generate_parameter_library>0.3.3. If it is not installed as a ROS 2 package already, install it as python package from source
+```bash
+cd
+git clone https://github.com/PickNikRobotics/generate_parameter_library.git
+cd generate_parameter_library/generate_parameter_library_py/
+python3 -m pip install .
+```
+5. Building of the documentation. Depends on what you want to do. See either single version or multiversion below.
 
 If you want to see results run: `python3 -m http.server --directory <path_to_control.ros.org>/_build/html <port>` and then open a browser to `localhost:<port>`
  (Or just open `_build/html/index.html` in your browser.)


### PR DESCRIPTION
I forgot to update the build instructions with the generate_parameter_library extension with #97 

I also removed its manual dependency installation now, because https://github.com/PickNikRobotics/generate_parameter_library/pull/123 got merged already.