### PR TITLE
Add simulators page

### DIFF
--- a/doc/simulators/simulators.rst
+++ b/doc/simulators/simulators.rst
@@ -1,0 +1,14 @@
+.. _simulators:
+
+#################
+Simulators
+#################
+
+This page hosts a list of supported simulators with ros2_control implementations.
+To add your ros2_control integration, submit a PR to this page on Github!
+
+* `Gazebo Classic <https://github.com/ros-controls/gazebo_ros2_control>`__
+* `Gazebo <https://github.com/ros-controls/gazebo_ros2_control>`__
+* `Isaac Sim <https://moveit.picknik.ai/main/doc/how_to_guides/isaac_panda/isaac_panda_tutorial.html>`__
+* `Webots <https://github.com/cyberbotics/webots_ros2/tree/master/webots_ros2_control>`__
+* Custom interfaces to simulators with a `Topic Based System <https://github.com/PickNikRobotics/topic_based_ros2_control>`__

--- a/index.rst
+++ b/index.rst
@@ -9,9 +9,10 @@ Welcome to the ros2_control documentation!
    doc/getting_started/getting_started.rst
    doc/ros2_control/doc/index.rst
    doc/ros2_controllers/doc/controllers_index.rst
-   doc/ros2_control/ros2controlcli/doc/userdoc.rst
-   doc/differences_to_ros1/differences_to_ros1.rst
    doc/ros2_control_demos/doc/index.rst
+   doc/ros2_control/ros2controlcli/doc/userdoc.rst
+   doc/simulators/simulators.rst
+   doc/differences_to_ros1/differences_to_ros1.rst
    doc/supported_robots/supported_robots.rst
    doc/resources/resources.rst
    doc/contributing/contributing.rst


### PR DESCRIPTION
I propose adding a page with a list of simulators with ros2_control integration.

In future, I'd like to integrate the gazebo_ros2_control and ign_ros2_control documentation here directly as well, what you think?