### PR TITLE
Add gazebo/gz_ros2_control

### DIFF
--- a/doc/simulators/gazebo_ros2_control
+++ b/doc/simulators/gazebo_ros2_control
@@ -1,0 +1,1 @@
+../../../gazebo_ros2_control/

--- a/doc/simulators/gz_ros2_control
+++ b/doc/simulators/gz_ros2_control
@@ -1,0 +1,1 @@
+../../../gz_ros2_control/

--- a/doc/simulators/simulators.rst
+++ b/doc/simulators/simulators.rst
@@ -1,14 +1,23 @@
 .. _simulators:
 
-#################
-Simulators
-#################
+######################
+Simulator Integrations
+######################
 
-This page hosts a list of supported simulators with ros2_control implementations.
-To add your ros2_control integration, submit a PR to this page on Github!
+Hosted by ros-controls
+---------------------------------------------
 
-* `Gazebo <https://github.com/ros-controls/gz_ros2_control>`__
-* `Gazebo Classic <https://github.com/ros-controls/gazebo_ros2_control>`__
+.. toctree::
+   :titlesonly:
+
+   Gazebo <gz_ros2_control/doc/index.rst>
+   Gazebo Classic <gazebo_ros2_control/doc/index.rst>
+
+Community
+---------------------------------------------
+This page hosts a list of supported simulators with *ros2_control* integration.
+To add your *ros2_control* integration, submit a PR to this page on Github!
+
 * `Isaac Sim <https://moveit.picknik.ai/main/doc/how_to_guides/isaac_panda/isaac_panda_tutorial.html>`__
 * `Webots <https://github.com/cyberbotics/webots_ros2/tree/master/webots_ros2_control>`__
 * Custom interfaces to simulators with a `Topic Based System <https://github.com/PickNikRobotics/topic_based_ros2_control>`__


### PR DESCRIPTION
As suggested with #108: I'd like to add gazebo_ros2_control and gz_ros2_control to control.ros.org

A preview, until the ReST files are merged in the two repos.

![image](https://github.com/ros-controls/control.ros.org/assets/3367244/2760c9d2-486b-4469-a1e5-aa1b54ed9afd)
