### PR TITLE
Add workflow to detect warnings

### DIFF
--- a/.github/workflows/sphinx-check-warnings.yml
+++ b/.github/workflows/sphinx-check-warnings.yml
@@ -1,0 +1,37 @@
+name: "Build & Deploy Page"
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+  schedule:
+  # Run every morning to ensure component documentation is up to date on deployment
+   - cron: '23 5 * * *'
+  pull_request: # only runs up through build of sphinx
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.8'
+        cache: 'pip'
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade --requirement requirements.txt
+    - name: Install generate_parameter_library
+      run: |
+        cd
+        git clone https://github.com/PickNikRobotics/generate_parameter_library.git
+        cd generate_parameter_library/generate_parameter_library_py/
+        python -m pip install .
+    - name: Build multiversion considering warnings as errors
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        make multiversion-with-errors

--- a/.github/workflows/sphinx-check-warnings.yml
+++ b/.github/workflows/sphinx-check-warnings.yml
@@ -1,4 +1,4 @@
-name: "Build & Deploy Page"
+name: "Check Page for Warnings"
 on:
   workflow_dispatch:
   push:

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,17 @@ multiversion: Makefile
 	@echo Step 4: Create correct index
 	@echo "<html><head><meta http-equiv=\"refresh\" content=\"0; url=master/index.html\" /></head></html>" > "$(BUILDDIR)"/html/index.html
 
+multiversion-with-errors: Makefile
+	@echo Building multi version documentation without API
+	@echo Step 1: Creating temporary commits
+	./make_help_scripts/add_tmp_commits
+	@echo Step 2: Build multi version documentation
+	sphinx-multiversion $(SPHINXOPTS) -W --keep-going $(SOURCEDIR) $(BUILDDIR)/html
+	@echo Step 3: Deleting temporary commits
+	./make_help_scripts/delete_tmp_commits
+	@echo Step 4: Create correct index
+	@echo "<html><head><meta http-equiv=\"refresh\" content=\"0; url=master/index.html\" /></head></html>" > "$(BUILDDIR)"/html/index.html
+
 multiversion-with-api: Makefile
 	@echo Building multi version documentation with API
 	@echo Step 1: Creating temporary commits

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Status
 
-[![Build & Deploy Page](https://github.com/ros-controls/control.ros.org/actions/workflows/sphinx-make-page.yml/badge.svg)](https://github.com/ros-controls/control.ros.org/actions/workflows/sphinx-make-page.yml)
+[![Build & Deploy Page](https://github.com/ros-controls/control.ros.org/actions/workflows/sphinx-make-page.yml/badge.svg)](https://github.com/ros-controls/control.ros.org/actions/workflows/sphinx-make-page.yml)[![Sphinx Warnings](https://github.com/ros-controls/control.ros.org/actions/workflows/sphinx-check-warnings.yml/badge.svg?branch=master)](https://github.com/ros-controls/control.ros.org/actions/workflows/sphinx-check-warnings.yml)
 
 
 # control.ros.org


### PR DESCRIPTION
`SPHINXOPTS = "-W --keep-going"` should return an error if any warning. 

I created a new CI action to check this, but haven't it included in the existing actions. It could be useful to detect some broken ReST files in the included repos, but does not abort the deployment of the page.

- [x] https://github.com/ros-controls/ros2_controllers/pull/658
- [x] https://github.com/ros-controls/ros2_controllers/pull/657
- [x] https://github.com/ros-controls/control.ros.org/pull/115
- [x] https://github.com/ros-controls/control.ros.org/pull/114
- [ ] https://github.com/ros-controls/ros2_controllers/pull/636