### PR TITLE
Fix link-checker workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ linkcheck-all-subrepos-with-api: Makefile
 	./make_help_scripts/add_sub_repos
 	@echo Step 4: Check links
 	cp -r $(BUILDDIR)/html/doc/api/. doc/api/
-	make linkcheck | grep broken
+	make linkcheck
 	rm -rf doc/api/
 
 multiversion: Makefile


### PR DESCRIPTION
I was not aware that an error in a piped command does not make the script fail.

I removed the pipe -> more verbose output but make target and, thus, workflow should fail now.