### PR TITLE
Fix image targets and permanent redirections

### DIFF
--- a/doc/acknowledgements/acknowledgements.rst
+++ b/doc/acknowledgements/acknowledgements.rst
@@ -25,9 +25,9 @@ The project has received major contributions from the following companies and in
 |rosin_ack_logo_wide|
 
 Supported by ROSIN - ROS-Industrial Quality-Assured Robot Software Components.
-More information: http://rosin-project.eu
+More information: https://www.rosin-project.eu
 
-This project has received funding from the European Union’s Horizon 2020
+This project has received funding from the European Union's Horizon 2020
 research and innovation programme under grant agreement no. 732287.
 
 .. |rosin_ack_logo_wide| image:: images/rosin_ack_logo_wide.png

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -177,7 +177,7 @@ The example files can be found in the `ros2_control_demos`_ repository.
    You can use a default `ros2_control node`_ (recommended) or integrate the controller manager in your software stack.
    (`Example launch file for RRBot <https://github.com/ros-controls/ros2_control_demos/blob/{REPOS_FILE_BRANCH}/example_1/bringup/launch/rrbot.launch.py>`_)
 
-*NOTE:* You could alternatively use a script to create setup a `skeleton of the "hardware_interface" package by using the scripts <https://stoglrobotics.github.io/ros_team_workspace/master/use-cases/ros2_control/setup_robot_hardware_interface.html>`_ provided by one of our maintainers.
+*NOTE:* You could alternatively use a script to create setup a `skeleton of the "hardware_interface" package by using the scripts <https://rtw.stoglrobotics.de/master/use-cases/ros2_control/setup_robot_hardware_interface.html>`_ provided by one of our maintainers.
 
 
 .. _ros2_control: https://github.com/ros-controls/ros2_control

--- a/doc/resources/resources.rst
+++ b/doc/resources/resources.rst
@@ -189,99 +189,72 @@ Generated images for the presentation which can be useful also for the documenta
 
 Overview of ros2_control
   .. image:: images/ros2_control_overview.png
-     :target: ../../_images/ros2_control_overview.png
 
 ros2_control robot integration with MoveIt2
   .. image:: images/ros2_control_robot_integration_with_moveit2.png
-     :target: ../../_images/jros2_control_robot_integration_with_moveit2.png
-
 
 Architecture of complex controller and semantic components:
   .. image:: images/complex_controllers_and_semantic_components.png
-     :target: ../../_images/jcomplex_controllers_and_semantic_components.png
-
 
 Architecture of command and state interfaces:
   .. image:: images/command_and_state_interfaces.png
-     :target: ../../_images/jcommand_and_state_interfaces.png
-
 
 Lifecycle of hardware interfaces:
   .. image:: images/hardware_interface_lifecycle.png
-     :target: ../../_images/jhardware_interface_lifecycle.png
-
 
 ros2_control integration with MoveIt2
   .. image:: images/ros2_control_robot_integration_with_moveit2.png
-     :target: ../../_images/jros2_control_robot_integration_with_moveit2.png
 
 Controllers architecture with chained controllers - admittance controller example
   .. image:: images/ros2_control_mobile_manipulator_control_arch_admittance_chaining.png
-     :target: ../../_images/jros2_control_mobile_manipulator_control_arch_admittance_chaining.png
 
 Controllers architecture with chained controllers - admittance controller example (URDF)
   .. image:: images/ros2_control_mobile_manipulator_controllers_admittance_chaining.png
-     :target: ../../_images/jros2_control_mobile_manipulator_controllers_admittance_chaining.png
 
 Controllers architecture without chained controllers - admittance controller example
   .. image:: images/ros2_control_mobile_manipulator_control_arch_admittance_without_chaining.png
-     :target: ../../_images/jros2_control_mobile_manipulator_control_arch_admittance_without_chaining.png
 
 Controllers architecture with chained controllers - mobile base controller example
   .. image:: images/ros2_control_mobile_manipulator_control_arch_base_chaining.png
-     :target: ../../_images/jros2_control_mobile_manipulator_control_arch_base_chaining.png
 
 Controllers architecture with chained controllers - mobile base controller example (URDF)
   .. image:: images/ros2_control_mobile_manipulator_controllers_base_chaining.png
-     :target: ../../_images/jros2_control_mobile_manipulator_controllers_base_chaining.png
 
 Controllers architecture without chained controllers - admittance controller example
   .. image:: images/ros2_control_mobile_manipulator_control_arch_base_without_chaining.png
-     :target: ../../_images/jros2_control_mobile_manipulator_control_arch_base_without_chaining.png
 
 Controllers architecture - overview
   .. image:: images/ros2_control_mobile_manipulator_control_arch_convoluted_controllers.png
-     :target: ../../_images/jros2_control_mobile_manipulator_control_arch_convoluted_controllers.png
 
 Controllers architecture - URDF
   .. image:: images/ros2_control_mobile_manipulator_controllers_convoluted_controllers.png
-     :target: ../../_images/jros2_control_mobile_manipulator_controllers_convoluted_controllers.png
 
 Hardware architecture - independent communication to the hardware (modular hardware)
   .. image:: images/ros2_control_mobile_manipulator_control_arch_independent_hardware.png
-     :target: ../../_images/jros2_control_mobile_manipulator_control_arch_independent_hardware.png
 
 Hardware architecture - independent communication to the hardware (modular hardware) (URDF)
   .. image:: images/ros2_control_mobile_manipulator_control_arch_independent_hardware_urdf.png
-     :target: ../../_images/jros2_control_mobile_manipulator_control_arch_independent_hardware_urdf.png
 
 Hardware architecture - gripper communication through Arm
   .. image:: images/ros2_control_mobile_manipulator_control_arch_gripper_through_arm_comms.png
-     :target: ../../_images/jros2_control_mobile_manipulator_control_arch_gripper_through_arm_comms.png
 
 Hardware architecture - gripper communication through Arm (URDF)
   .. image:: images/ros2_control_mobile_manipulator_control_arch_gripper_through_arm_comms_urdf.png
-     :target: ../../_images/jros2_control_mobile_manipulator_control_arch_gripper_through_arm_comms_urdf.png
 
 Hardware architecture - monolitic communication to hardware
   .. image:: images/ros2_control_mobile_manipulator_control_arch_monolitic_hardware.png
-     :target: ../../_images/jros2_control_mobile_manipulator_control_arch_monolitic_hardware.png
 
 Hardware architecture - monolitic communication to hardware (URDF)
   .. image:: images/ros2_control_mobile_manipulator_control_arch_monolitic_hardware_urdf.png
-     :target: ../../_images/jros2_control_mobile_manipulator_control_arch_monolitic_hardware_urdf.png
 
 Hardware architecture - multiple hardware in one controller manager
   .. image:: images/ros2_control_mobile_manipulator_control_arch_multi_robots_in_one_controller_manager.png
-     :target: ../../_images/jros2_control_mobile_manipulator_control_arch_multi_robots_in_one_controller_manager.png
 
 Example files - ros2_control - "Controlko" mobile manipulator
   .. image:: images/ros2_control_mobile_manipulator.png
-     :target: ../../_images/jros2_control_mobile_manipulator.png
 
 Example files - ros2_control - "Controlko" mobile manipulator (URDF)
   .. image:: images/ros2_control_mobile_manipulator_controllers.png
-     :target: ../../_images/jros2_control_mobile_manipulator_controllers.png
 
 .. |CC-BY| image:: https://i.creativecommons.org/l/by/4.0/88x31.png
 .. _CC-BY: http://creativecommons.org/licenses/by/4.0/

--- a/doc/resources/resources.rst
+++ b/doc/resources/resources.rst
@@ -257,4 +257,4 @@ Example files - ros2_control - "Controlko" mobile manipulator (URDF)
   .. image:: images/ros2_control_mobile_manipulator_controllers.png
 
 .. |CC-BY| image:: https://i.creativecommons.org/l/by/4.0/88x31.png
-.. _CC-BY: http://creativecommons.org/licenses/by/4.0/
+.. _CC-BY: https://creativecommons.org/licenses/by/4.0/

--- a/index.rst
+++ b/index.rst
@@ -61,7 +61,7 @@ Bug reports and feature requests
    Provide relevant information regarding the operating system, ROS distribution, etc.
 
 Questions
-   Please use `ROS Answers <https://answers.ros.org/>`_ and tag your questions with ``ros2_control``.
+   Please use `ROS Answers <https://answers.ros.org/questions>`_ and tag your questions with ``ros2_control``.
 
 General discussions
    Please use `ROS Discourse`_.


### PR DESCRIPTION
@destogl the image targets don't work with the link checker (they had typos in it, but the given paths isn't searchable by the linkchecker at all). Are they necessary? One can open the image with every browser from the context menu anyways.

Furthermore, I updated permanent redirections of some links.