### PR TITLE
Fix typo in badge-link

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -18,7 +18,7 @@ Building from Source
 .. raw:: html
 
     <a href="https://github.com/ros-controls/control.ros.org/actions/workflows/{DISTRO}-binary-build-main.yml">
-        <img src="https://github.com/ros-controls/control.ros.org/actions/workflows/{DISTRO}g-binary-build-main.yml/badge.svg" alt="{DISTRO} Binary Build - main"/></a>
+        <img src="https://github.com/ros-controls/control.ros.org/actions/workflows/{DISTRO}-binary-build-main.yml/badge.svg" alt="{DISTRO} Binary Build - main"/></a>
 
 If you want to install the framework from source, e.g., for contributing to the framework, use the following commands:
 


### PR DESCRIPTION
I made a mistake with the linked badge in the getting-started section. Now it works as expected:
![image](https://github.com/ros-controls/control.ros.org/assets/3367244/5d19143f-d355-4391-b8bc-54fd3a11fd81)
