### PR TITLE
Add Flexiv Robotics robots to list of supported robots

### DIFF
--- a/doc/supported_robots/supported_robots.rst
+++ b/doc/supported_robots/supported_robots.rst
@@ -8,6 +8,7 @@ Official (supported by robot manufacturer):
 
 * `Universal Robots <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver>`_
 * `Franka Emika research robots <https://github.com/frankaemika/franka_ros2>`_
+* `Flexiv Robotics Rizon robots <https://github.com/flexivrobotics/flexiv_ros2>`_
 
 Unofficial (from the community):
 


### PR DESCRIPTION
Add Flexiv Robotics Rizon robots

Official support ROS 2 driver: https://github.com/flexivrobotics/flexiv_ros2