### PR TITLE
Ignore false-positive github link errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ linkcheck-all-subrepos-with-api: Makefile
 	@echo Step 4: Check links
 	cp -r $(BUILDDIR)/html/doc/api/. doc/api/
 	./make_help_scripts/check_links
-	rm -rf doc/api/ linkcheck.log
+	rm -rf doc/api/
 
 multiversion: Makefile
 	@echo Building multi version documentation without API

--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,7 @@ linkcheck-all-subrepos-with-api: Makefile
 	@echo Step 3: Cloning all subrepositories again
 	./make_help_scripts/add_sub_repos
 	@echo Step 4: Check links
-	cp -r $(BUILDDIR)/html/doc/api/. doc/api/
-	./make_help_scripts/check_links
-	rm -rf doc/api/
+	./make_help_scripts/check_links $(BUILDDIR)
 
 multiversion: Makefile
 	@echo Building multi version documentation without API

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ linkcheck-all-subrepos-with-api: Makefile
 	@echo Step 4: Check links
 	cp -r $(BUILDDIR)/html/doc/api/. doc/api/
 	./make_help_scripts/check_links
-	rm -rf doc/api/
+	rm -rf doc/api/ linkcheck.log
 
 multiversion: Makefile
 	@echo Building multi version documentation without API

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ linkcheck-all-subrepos-with-api: Makefile
 	./make_help_scripts/add_sub_repos
 	@echo Step 4: Check links
 	cp -r $(BUILDDIR)/html/doc/api/. doc/api/
-	make linkcheck
+	./make_help_scripts/check_links
 	rm -rf doc/api/
 
 multiversion: Makefile

--- a/make_help_scripts/check_links
+++ b/make_help_scripts/check_links
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# This script is used to check the links in the ROS documentation.
+# due to a bug in the sphinx linkchecker, github anchors are false positives and
+# have to be explicitly ignored
+# https://github.com/sphinx-doc/sphinx/issues/9016
+make linkcheck > linkcheck.log
+if grep broken linkcheck.log | grep -v -E 'github.*Anchor'; then
+    num_broken=$(grep broken linkcheck.log | grep -v -E 'github.*Anchor' | wc -l)
+    echo "Broken links found in linkcheck.log: $num_broken"
+    exit 1
+fi

--- a/make_help_scripts/check_links
+++ b/make_help_scripts/check_links
@@ -3,12 +3,20 @@
 # due to a bug in the sphinx linkchecker, github anchors are false positives and
 # have to be explicitly ignored
 # https://github.com/sphinx-doc/sphinx/issues/9016
-make linkcheck > linkcheck.log
-if grep broken linkcheck.log | grep -v -E 'github.*Anchor'; then
-    num_broken=$(grep broken linkcheck.log | grep -v -E 'github.*Anchor' | wc -l)
+
+LOGFILE="linkcheck.log"
+cleanup () {
+  rm "$LOGFILE"
+	rm -rf doc/api/
+}
+
+cp -r $1/html/doc/api/. doc/api/
+make linkcheck > "$LOGFILE"
+if grep broken "$LOGFILE" | grep -v -E 'github.*Anchor'; then
+    num_broken=$(grep broken "$LOGFILE" | grep -v -E 'github.*Anchor' | wc -l)
     echo "Broken links found: $num_broken"
-    rm linkcheck.log
+    cleanup
     exit 1
 fi
-rm linkcheck.log
+cleanup
 exit 0

--- a/make_help_scripts/check_links
+++ b/make_help_scripts/check_links
@@ -6,6 +6,9 @@
 make linkcheck > linkcheck.log
 if grep broken linkcheck.log | grep -v -E 'github.*Anchor'; then
     num_broken=$(grep broken linkcheck.log | grep -v -E 'github.*Anchor' | wc -l)
-    echo "Broken links found in linkcheck.log: $num_broken"
+    echo "Broken links found: $num_broken"
+    rm linkcheck.log
     exit 1
 fi
+rm linkcheck.log
+exit 0


### PR DESCRIPTION
Due to a [bug in the sphinx linkchecker,](https://github.com/sphinx-doc/sphinx/issues/9016) github anchors are false positives and have to be explicitly ignored.

Fixes #131 