### PR TITLE
Add autosectionlabel

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -84,8 +84,12 @@ extensions = [
     "sphinx_multiversion",
     "sphinx_copybutton",
     "generate_parameter_library",
-    'sphinx_tabs.tabs'
+    'sphinx_tabs.tabs',
+    "sphinx.ext.autosectionlabel",
 ]
+
+# Make sure the target is unique
+autosectionlabel_prefix_document = True
 
 # By default, tabs can be closed by selecting the open tab
 sphinx_tabs_disable_tab_closing = True


### PR DESCRIPTION
This extension adds labels automatically to all section headers, which can then easily be referenced to.

This needs unique header names:
- https://github.com/ros-controls/ros2_controllers/pull/743
- https://github.com/ros-controls/ros2_control_demos/pull/341