### PR TITLE
Create jobs to check for warnings

### DIFF
--- a/.github/workflows/sphinx-check-warnings-humble.yml
+++ b/.github/workflows/sphinx-check-warnings-humble.yml
@@ -1,9 +1,9 @@
-name: "Check Page for Warnings"
+name: "Check Page for Warnings Humble"
 on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - humble
   schedule:
   # Run every morning to ensure component documentation is up to date on deployment
    - cron: '23 5 * * *'
@@ -14,6 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        ref: humble
         fetch-depth: 0
     - uses: actions/setup-python@v4
       with:

--- a/.github/workflows/sphinx-check-warnings-iron.yml
+++ b/.github/workflows/sphinx-check-warnings-iron.yml
@@ -1,0 +1,39 @@
+name: "Check Page for Warnings Iron"
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - iron
+  schedule:
+  # Run every morning to ensure component documentation is up to date on deployment
+   - cron: '23 5 * * *'
+
+jobs:
+  build-halt-on-warnings:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: iron
+        fetch-depth: 0
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+        cache: 'pip'
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade --requirement requirements.txt
+      shell: bash
+    - name: Install generate_parameter_library
+      run: |
+        cd
+        git clone https://github.com/PickNikRobotics/generate_parameter_library.git
+        cd generate_parameter_library/generate_parameter_library_py/
+        python -m pip install .
+      shell: bash
+    - name: Build single version considering warnings as errors
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        make html-all-subrepos-with-errors

--- a/.github/workflows/sphinx-check-warnings-rolling.yml
+++ b/.github/workflows/sphinx-check-warnings-rolling.yml
@@ -1,0 +1,38 @@
+name: "Check Page for Warnings Rolling"
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+  schedule:
+  # Run every morning to ensure component documentation is up to date on deployment
+   - cron: '23 5 * * *'
+
+jobs:
+  build-halt-on-warnings:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+        cache: 'pip'
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade --requirement requirements.txt
+      shell: bash
+    - name: Install generate_parameter_library
+      run: |
+        cd
+        git clone https://github.com/PickNikRobotics/generate_parameter_library.git
+        cd generate_parameter_library/generate_parameter_library_py/
+        python -m pip install .
+      shell: bash
+    - name: Build single version considering warnings as errors
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        make html-all-subrepos-with-errors

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # Status
 
-[![Build & Deploy Page](https://github.com/ros-controls/control.ros.org/actions/workflows/sphinx-make-page.yml/badge.svg)](https://github.com/ros-controls/control.ros.org/actions/workflows/sphinx-make-page.yml)[![Sphinx Warnings](https://github.com/ros-controls/control.ros.org/actions/workflows/sphinx-check-warnings.yml/badge.svg?branch=master)](https://github.com/ros-controls/control.ros.org/actions/workflows/sphinx-check-warnings.yml)[![Broken Links](https://github.com/ros-controls/control.ros.org/actions/workflows/sphinx-check-links.yml/badge.svg?branch=master)](https://github.com/ros-controls/control.ros.org/actions/workflows/sphinx-check-links.yml)
+[![Build & Deploy Page](https://github.com/ros-controls/control.ros.org/actions/workflows/sphinx-make-page.yml/badge.svg)](https://github.com/ros-controls/control.ros.org/actions/workflows/sphinx-make-page.yml)[![Broken Links](https://github.com/ros-controls/control.ros.org/actions/workflows/sphinx-check-links.yml/badge.svg?branch=master)](https://github.com/ros-controls/control.ros.org/actions/workflows/sphinx-check-links.yml)
 
+[![Sphinx Warnings Rolling](https://github.com/ros-controls/control.ros.org/actions/workflows/sphinx-check-warnings-rolling.yml/badge.svg?branch=master)](https://github.com/ros-controls/control.ros.org/actions/workflows/sphinx-check-warnings-rolling.yml)
+[![Sphinx Warnings Iron](https://github.com/ros-controls/control.ros.org/actions/workflows/sphinx-check-warnings-iron.yml/badge.svg?branch=master)](https://github.com/ros-controls/control.ros.org/actions/workflows/sphinx-check-warnings-iron.yml)
+[![Sphinx Warnings Humble](https://github.com/ros-controls/control.ros.org/actions/workflows/sphinx-check-warnings-humble.yml/badge.svg?branch=master)](https://github.com/ros-controls/control.ros.org/actions/workflows/sphinx-check-warnings-humble.yml)
 
 # control.ros.org
 https://control.ros.org/


### PR DESCRIPTION
Cron-jobs work only from workflow files inside the master branch. 

The check-for-warning job uses only a single-version build, because the old distros throw too many warnings (foxy, galactic) -> I added jobs for every actively maintained version of the docs.