### PR TITLE
Using sphinx's download role for PDFs

### DIFF
--- a/doc/resources/resources.rst
+++ b/doc/resources/resources.rst
@@ -33,7 +33,7 @@ Summary:
 
 2023-02 ROS Meetup Munich #5
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-`Presentation: Tricycle Controller with ros2_control <https://github.com/ros-controls/control.ros.org/blob/master/doc/resources/presentations/pixel_robotics_tricycle_controller_with_ros2_control.pdf>`_
+:download:`Presentation: Tricycle Controller with ros2_control <presentations/pixel_robotics_tricycle_controller_with_ros2_control.pdf>`
 
 `Meetup event link <https://www.meetup.com/robot-operating-system-ros/events/290966049/>`_
 
@@ -49,7 +49,7 @@ Summary:
 
 2022-12 ROS-Industrial Conference 2022
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-`Presentation: ros2_control - Kernel for ROS 2 controlled robots <https://github.com/ros-controls/control.ros.org/blob/master/doc/resources/presentations/2022-12_ROS-I_Conference-ros2_control_-_Kernel_for_ROS_2_controlled_robots.pdf>`_
+:download:`Presentation: ros2_control - Kernel for ROS 2 controlled robots <presentations/2022-12_ROS-I_Conference-ros2_control_-_Kernel_for_ROS_2_controlled_robots.pdf>`
 
   Summary:
     ros2_control is a hardware-agnostic control framework focusing on the modular composition of control systems for robots, sharing of controllers as well as real-time performance. The framework provides “kernel” functionality for robots by abstracting the hardware and doing heavy low-level management, for example, hardware lifecycle, communication and access control.
@@ -62,7 +62,7 @@ Summary:
 
 2022-10 ROSCon 2022
 ,,,,,,,,,,,,,,,,,,,
-`Presentation: A practitioner's guide to ros2_control <https://raw.githubusercontent.com/ros-controls/control.ros.org/master/doc/resources/presentations/2022-10_ROSCon2022_A_practitioners_guide_to_ros2_control.pdf>`_
+:download:`Presentation: A practitioner's guide to ros2_control <presentations/2022-10_ROSCon2022_A_practitioners_guide_to_ros2_control.pdf>`
 
   Summary:
     ros2_control is a hardware-agnostic control framework focusing on the modular composition of control systems for robots, sharing of controllers as well as real-time performance. The framework provides controller-lifecycle and hardware management on top of abstractions of real or virtual hardware interfaces.
@@ -80,7 +80,7 @@ Summary:
 
 2022-06 ROSCon Fr 2022
 ,,,,,,,,,,,,,,,,,,,,,,,
-`Presentation: What is new in the best (and only) control framework for ROS2 - ros2_control <https://raw.githubusercontent.com/ros-controls/control.ros.org/master/doc/resources/presentations/2022-06_ROSConFr_What-is-new-in-ros2_control.pdf>`_
+:download:`Presentation: What is new in the best (and only) control framework for ROS2 - ros2_control <presentations/2022-06_ROSConFr_What-is-new-in-ros2_control.pdf>`
 
   Summary:
     ros2_control is a hardware-agnostic control framework with a focus on both real-time performance and sharing of controllers. The framework has become one of the main utilities for abstracting hardware and low-level control for 3rd party solutions like `MoveIt2` and `Nav2` systems.
@@ -97,7 +97,7 @@ Summary:
 
 2021-10 ROS World 2021
 ,,,,,,,,,,,,,,,,,,,,,,,,
-`Presentation: ros2_control - The future of ros_control <https://raw.githubusercontent.com/ros-controls/control.ros.org/master/doc/resources/presentations/2021-10_ROS_World_2021-ros2_control_The_future_of_ros_control.pdf>`_
+:download:`Presentation: ros2_control - The future of ros_control <presentations/2021-10_ROS_World_2021-ros2_control_The_future_of_ros_control.pdf>`
 
   Summary:
     ros2_control is a robot-agnostic control framework with a focus on both real-time performance and sharing of controllers. The framework offers controller lifecycle and hardware resource management, as well as abstractions on hardware interfaces.
@@ -113,7 +113,7 @@ Summary:
     - Denis Stogl (Stogl Robotics Consulting)
 
 
-`Presentation: Making a robot ROS 2 powered - a case study using the UR manipulators <https://raw.githubusercontent.com/ros-controls/control.ros.org/master/doc/resources/presentations/2021-10_ROS_World-Making_a_robot_ROS_2_powered.pdf>`_
+:download:`Presentation: Making a robot ROS 2 powered - a case study using the UR manipulators <presentations/2021-10_ROS_World-Making_a_robot_ROS_2_powered.pdf>`
 
   Summary:
     With the release of ros2_control and MoveIt 2, ROS 2 Foxy finally has all the “ingredients” needed to power a robot with similar features as in ROS 1. We present the driver for Universal Robot’s manipulators as a real-world example of how robots can be run using ROS 2. We show how to realize multi-interface support for position and velocity commands in the driver and how to support scaling controllers while respecting factors set on the teach pendant. Finally, we show how this real-world example influences development of ros2_control to support non-joint related inputs and outputs in its real-time control loop.
@@ -129,8 +129,7 @@ Summary:
     - Dr. Andy Zelenak (PickNik Inc.)
     - Rune Søe-Knudsen (Universal Robots)
 
-
-`Presentation: Online Trajectory Generation and Admittance Control in ROS2 <https://raw.githubusercontent.com/ros-controls/control.ros.org/master/doc/resources/presentations/2021-10_ROS_World-Admittance_Control_in_ROS2.pdf>`_
+:download:`Presentation: Online Trajectory Generation and Admittance Control in ROS2 <presentations/2021-10_ROS_World-Admittance_Control_in_ROS2.pdf>`
 
   Summary:
     One of the top reasons to upgrade from ROS1 to ROS2 is better suitability for realtime tasks. We discuss the development of a new ROS2 controller to handle realtime contact tasks such as tool insertion with industrial robots. The admittance controller handles trajectories and single-waypoint streaming commands, making it compatible with MoveIt and many teleoperation frameworks. Part of the work involved ensuring kinematic limits (position/velocity/acceleration/jerk) are obeyed while limiting interaction forces with the environment. Finally, we give practical recommendations and examples of the admittance controller. A live demo will be shown at our booth.
@@ -146,7 +145,7 @@ Summary:
 
 2021-10-07 Weekly Robotics Meetup #13
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-`Meetup presentation: Getting started with ros2_control <https://raw.githubusercontent.com/ros-controls/control.ros.org/master/doc/resources/presentations/2021-1_WR_Meetup_Getting_started_with_ros2_control.pdf>`_
+:download:`Meetup presentation: Getting started with ros2_control <presentations/2021-1_WR_Meetup_Getting_started_with_ros2_control.pdf>`
 
   Summary:
     ros2_control is a robot-agnostic control framework with a focus on both real-time performance and sharing of controllers. The framework offers controller lifecycle and hardware-resource management, as well as abstractions on hardware interfaces.
@@ -178,7 +177,7 @@ Summary:
 
 2021-05 ROSCon Fr 2021
 ,,,,,,,,,,,,,,,,,,,,,,,
-`Presentation: Getting started with ros2_control <https://raw.githubusercontent.com/ros-controls/control.ros.org/master/doc/resources/presentations/2021-06_RosConFR_Getting_started_with_ros2_control.pdf>`_
+:download:`Presentation: Getting started with ros2_control <presentations/2021-06_RosConFR_Getting_started_with_ros2_control.pdf>`
 
   Summary:
     The presentation gives a quick overview on the basic concepts and some simple implementation examples. We show implementing a simple Hardware Abstraction Layer (aka SystemComponent) and a forwarding controller. Once done, we also look into modifying the controller with the example goal of changing the type of the command topic.

--- a/doc/resources/roscon2023_workshop.rst
+++ b/doc/resources/roscon2023_workshop.rst
@@ -23,7 +23,7 @@ You will get a practical overview of concepts like controller chaining, hardware
 Slides
 ------
 
-`Presentation: ros2_control - ros2_control on Steroids <https://github.com/ros-controls/control.ros.org/blob/master/doc/resources/ROSCon2023_Workshop_ros2_control_on_Steroids.pdf>`_
+:download:`Presentation: ros2_control - ros2_control on Steroids <presentations/ROSCon2023_Workshop_ros2_control_on_Steroids.pdf>`
 
 Before coming to the conference
 -------------------------------


### PR DESCRIPTION
I merged a broken link with the last PR. But instead of absolute links to the github repo, we can use the download role to put it on the webserver and have a nice rendered link:
![image](https://github.com/ros-controls/control.ros.org/assets/3367244/51473535-09ae-41cb-b9a3-b531f9d6280a)
