### PR TITLE
Add hint for versions not being the latest

### DIFF
--- a/_templates/page.html
+++ b/_templates/page.html
@@ -1,0 +1,40 @@
+{% extends "!page.html" %}
+{% block header %}
+<div class="pageheader">
+  <div align="center">
+    <br/>
+    <table id="topnav-table">
+      <tr>
+        <td valign="middle">
+          ROS Resources:
+            <a href="http://discourse.ros.org/">Discussion Forum</a>
+            |
+            <a href="http://status.ros.org/">Service Status</a>
+            |
+            <a href="https://robotics.stackexchange.com/">Q&A Robotics Stack Exchange</a>
+
+        </td>
+      </tr>
+    </table>
+  </div>
+</div>
+{% endblock %}
+{% block body %}
+{% if current_version and latest_version and current_version != latest_version %}
+<p>
+  <strong>
+    {% if current_version.name|string() in eol_versions %}
+    You're reading the documentation for a version of ROS 2 that has reached its EOL (end-of-life), and is no longer officially supported.
+    If you want up-to-date information, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
+    {% elif current_version.is_released %}
+    You're reading the documentation for an older, but still supported, version of ROS 2.
+    For information on the latest version, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
+    {% else %}
+    You're reading the documentation for a development version.
+    For the latest released version, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
+    {% endif %}
+  </strong>
+</p>
+{% endif %}
+{{ super() }}
+{% endblock %}%

--- a/_templates/versions.html
+++ b/_templates/versions.html
@@ -7,21 +7,21 @@
   </span>
   <div class="rst-other-versions">
     <dl>
-      <dt>In Development</dt>
-      {%- for item in versions.in_development|sort(reverse=True) %}
-      <dd><a href="{{ item.url }}">{{ item.name|title }} (latest)</a></dd>
-      {%- endfor %}
-    </dl>
-    <dl>
       <dt>Releases</dt>
       {%- for item in versions.releases|sort(reverse=True) %}
         {%- if item.name == latest_version.name %}
-        <dd><a href="{{ item.url }}">{{ item.name|title }} (recommended)</a></dd><br>
+        <dd><a href="{{ item.url }}">{{ item.name|title }} (latest)</a></dd><br>
         {%- elif item.name in eol_versions %}
         <dd><a href="{{ item.url }}">{{ item.name|title }} (EOL)</a></dd><br>
         {% else %}
         <dd><a href="{{ item.url }}">{{ item.name|title }}</a></dd><br>
         {%- endif %}
+      {%- endfor %}
+    </dl>
+    <dl>
+      <dt>In Development</dt>
+      {%- for item in versions.in_development|sort(reverse=True) %}
+      <dd><a href="{{ item.url }}">{{ item.name|title }}</a></dd>
       {%- endfor %}
     </dl>
   </div>


### PR DESCRIPTION
Adding a warning to the top of every page if not the latest version is selected, as well known from docs.ros.org
(template copied over from https://github.com/ros2/ros2_documentation/blob/humble/source/_templates/page.html)
![image](https://github.com/ros-controls/control.ros.org/assets/3367244/5767bc51-c0ec-4cf0-926c-ed03374e5c00)
