### PR TITLE
Reorder the supported robots alphabetically and add TIAGo and PMB2 

### DIFF
--- a/doc/supported_robots/supported_robots.rst
+++ b/doc/supported_robots/supported_robots.rst
@@ -4,43 +4,42 @@ Supported Robots
 This page hosts a list of supported robots and references to them.
 To add your robot, submit a PR to this page on Github!
 
-Official (supported by robot manufacturer):
+Communication protocols
+------------------------
+- `CanOpen <https://github.com/ros-industrial/ros2_canopen>`_
+- `Ethercat <https://github.com/ICube-Robotics/ethercat_driver_ros2>`_
 
-* `Universal Robots <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver>`_
-* `Franka Emika research robots <https://github.com/frankaemika/franka_ros2>`_
-* `xArm <https://github.com/xarm-Developer/xarm_ros2>`_
-* `Flexiv Robotics Rizon robots <https://github.com/flexivrobotics/flexiv_ros2>`_
-* `igus/Commonplace Robotics <https://github.com/CommonplaceRobotics/iRC_ROS>`_
-* `Husarion ROSbot XL <https://github.com/husarion/rosbot_xl_ros>`_
-* `Husarion ROSbot 2R / 2 PRO <https://github.com/husarion/rosbot_ros>`_
-* `Husarion ROSbot XL with OpenMANIPULATOR-X (including MoveIt2) <https://husarion.com/tutorials/ros-projects/rosbot-xl-openmanipulator-x/>`_
-* `Clearpath Robotics Jackal J100 <https://docs.clearpathrobotics.com/docs/robots/outdoor_robots/jackal/user_manual_jackal/>`_
-* `Clearpath Robotics Husky A200 <https://docs.clearpathrobotics.com/docs/robots/outdoor_robots/husky/user_manual_husky>`_
-* `Clearpath Robotics Warthog W200 <https://docs.clearpathrobotics.com/docs/robots/outdoor_robots/warthog/user_manual_warthog>`_
+End-effectors
+--------------
+- `Schunk SVH 5-finger Hand <https://github.com/SCHUNK-SE-Co-KG/schunk_svh_ros_driver/tree/ros2-humble>`_
 
-Unofficial (from the community):
+Non robot-devices
+------------------
+- `Force Dimension haptic devices <https://github.com/ICube-Robotics/forcedimension_ros2>`_
+- `Hoverboard motors <https://github.com/DataBot-Labs/hoverboard_ros2_control>`_
+- `NDI measurement systems <https://github.com/ICube-Robotics/ndisys_ros2>`_
+- `ODrive Motor Controller <https://github.com/Factor-Robotics/odrive_ros2_control>`_
+- `ODRI Motor Controller <https://github.com/stack-of-tasks/ros2_hardware_interface_odri>`_
+- `PCA9685 16-Channel 12-bit PWM/Servo Driver <https://github.com/rosblox/pca9685_ros2_control>`_
 
-* `KUKA industrial robots (KUKA Robot Sensor Interface (RSI)) <https://github.com/dignakov/ros2_control_kuka_driver>`_
-* `KUKA IIWA (KUKA Fast Robot Interface (FRI)) <https://github.com/ICube-Robotics/iiwa_ros2>`_
-* `KUKA LBRs (IIWA 7/14 and Med 7/14 via KUKA Fast Robot Interface (FRI)) <https://github.com/lbr-stack/lbr_fri_ros2_stack>`_
-* `KUKA All Robots (iiQKA-ECI, Sunrise-FRI, KSS-RSI) <https://github.com/kroshu/ros2_kuka_drivers>`_
-* `ABB - EGM interface <https://github.com/PickNikRobotics/abb_ros2>`_
-* `Mitsubishi RV1A <https://github.com/ICube-Robotics/mrv1a_ros2>`_
+Official (supported by robot manufacturer)
+-------------------------------------------
+- `Clearpath Robotics Husky A200 <https://docs.clearpathrobotics.com/docs/robots/outdoor_robots/husky/user_manual_husky>`_
+- `Clearpath Robotics Jackal J100 <https://docs.clearpathrobotics.com/docs/robots/outdoor_robots/jackal/user_manual_jackal>`_
+- `Clearpath Robotics Warthog W200 <https://docs.clearpathrobotics.com/docs/robots/outdoor_robots/warthog/user_manual_warthog>`_
+- `Flexiv Robotics Rizon robots <https://github.com/flexivrobotics/flexiv_ros2>`_
+- `Husarion ROSbot 2R / 2 PRO <https://github.com/husarion/rosbot_ros>`_
+- `Husarion ROSbot XL <https://github.com/husarion/rosbot_xl_ros>`_
+- `Husarion ROSbot XL with OpenMANIPULATOR-X (including MoveIt2) <https://husarion.com/tutorials/ros-projects/rosbot-xl-openmanipulator-x/>`_
+- `igus/Commonplace Robotics <https://github.com/CommonplaceRobotics/iRC_ROS>`_
+- `Universal Robots <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver>`_
+- `xArm <https://github.com/xarm-Developer/xarm_ros2>`_
 
-Communication protocols:
-
-* `Ethercat <https://github.com/ICube-Robotics/ethercat_driver_ros2>`_
-* `CanOpen <https://github.com/ros-industrial/ros2_canopen>`_
-
-End-effectors:
-
-* `Schunk SVH 5-finger Hand <https://github.com/SCHUNK-SE-Co-KG/schunk_svh_ros_driver/tree/ros2-humble>`_
-
-Non robot-devices:
-
-* `Force Dimension haptic devices <https://github.com/ICube-Robotics/forcedimension_ros2>`_
-* `ODrive Motor Controller <https://github.com/Factor-Robotics/odrive_ros2_control>`_
-* `ODRI Motor Controller <https://github.com/stack-of-tasks/ros2_hardware_interface_odri>`_
-* `NDI measurement systems <https://github.com/ICube-Robotics/ndisys_ros2>`_
-* `PCA9685 16-Channel 12-bit PWM/Servo Driver <https://github.com/rosblox/pca9685_ros2_control>`_
-* `Hoverboard motors <https://github.com/DataBot-Labs/hoverboard_ros2_control>`_
+Unofficial (from the community)
+--------------------------------
+- `ABB - EGM interface <https://github.com/PickNikRobotics/abb_ros2>`_
+- `KUKA All Robots (iiQKA-ECI, Sunrise-FRI, KSS-RSI) <https://github.com/kroshu/ros2_kuka_drivers>`_
+- `KUKA IIWA (KUKA Fast Robot Interface (FRI)) <https://github.com/ICube-Robotics/iiwa_ros2>`_
+- `KUKA industrial robots (KUKA Robot Sensor Interface (RSI)) <https://github.com/dignakov/ros2_control_kuka_driver>`_
+- `KUKA LBRs (IIWA 7/14 and Med 7/14 via KUKA Fast Robot Interface (FRI)) <https://github.com/lbr-stack/lbr_fri_ros2_stack>`_
+- `Mitsubishi RV1A <https://github.com/ICube-Robotics/mrv1a_ros2>`_

--- a/doc/supported_robots/supported_robots.rst
+++ b/doc/supported_robots/supported_robots.rst
@@ -32,6 +32,8 @@ Official (supported by robot manufacturer)
 - `Husarion ROSbot XL <https://github.com/husarion/rosbot_xl_ros>`_
 - `Husarion ROSbot XL with OpenMANIPULATOR-X (including MoveIt2) <https://husarion.com/tutorials/ros-projects/rosbot-xl-openmanipulator-x/>`_
 - `igus/Commonplace Robotics <https://github.com/CommonplaceRobotics/iRC_ROS>`_
+- `PMB2 - Differential Drive Mobile Base <https://github.com/pal-robotics/pmb2_simulation/tree/humble-devel>`_
+- `TIAGo - Mobile Manipulator <https://github.com/pal-robotics/tiago_simulation/tree/humble-devel>`_
 - `Universal Robots <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver>`_
 - `xArm <https://github.com/xarm-Developer/xarm_ros2>`_
 


### PR DESCRIPTION
This PR contains 2 changes:
* Reorder the list alphabetically and format of respective headers
* Add TIAGo and PMB2 robots to the supported robots list