### PR TITLE
Add user_agent for link checker

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -207,6 +207,8 @@ macros = {
     "REPOS_FILE_BRANCH": repos_file_branch,
 }
 
+# set a user_agent for link checking
+user_agent = "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0"
 
 # Add any paths that contain custom themes here, relative to this directory.
 class RedirectFrom(Directive):


### PR DESCRIPTION
This might fix the link-checker 
```
Step 4: Check links
./make_help_scripts/check_links _build
make[1]: *** [Makefile:122: linkcheck] Error 1
(           index: line   49) broken    https://robotics.stackexchange.com/ - 403 Client Error: Forbidden for url: https://robotics.stackexchange.com/
Broken links found: 1
```
https://github.com/ros-controls/control.ros.org/actions/runs/8107023192/job/22157854574#step:8:2685
https://stackoverflow.com/questions/38489386/how-to-fix-403-forbidden-errors-when-calling-apis-using-python-requests
https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-user_agent