### PR TITLE
Restructure migration notes

### DIFF
--- a/doc/migration/differences_to_ros1.rst
+++ b/doc/migration/differences_to_ros1.rst
@@ -1,7 +1,7 @@
 .. _diff_to_ros1:
 
-Differences to ros_control (ROS1)
-=================================
+Differences to ros_control (ROS 1)
+==================================
 
 Hardware Structures - classes
 -----------------------------

--- a/doc/migration/migration.rst
+++ b/doc/migration/migration.rst
@@ -1,0 +1,31 @@
+.. _migration:
+
+Migration Guides
+=================================
+
+Coming from ros_control (ROS 1)
+********************************
+
+.. toctree::
+   :titlesonly:
+
+   differences_to_ros1.rst
+
+Between different ROS 2 distributions
+**************************************
+
+
+ros2_control
+-------------
+
+.. toctree::
+   :titlesonly:
+
+   Foxy to Galactic <../ros2_control/doc/migration/Foxy.rst>
+   Iron to Jazzy <../ros2_control/doc/migration/Iron.rst>
+
+
+ros2_controllers
+----------------
+
+There are no migration notes yet.

--- a/index.rst
+++ b/index.rst
@@ -12,7 +12,7 @@ Welcome to the ros2_control documentation!
    doc/ros2_control_demos/doc/index.rst
    doc/ros2_control/ros2controlcli/doc/userdoc.rst
    doc/simulators/simulators.rst
-   doc/differences_to_ros1/differences_to_ros1.rst
+   doc/migration/migration.rst
    doc/supported_robots/supported_robots.rst
    doc/resources/resources.rst
    doc/contributing/contributing.rst


### PR DESCRIPTION
Similar to https://navigation.ros.org/migration/index.html

The actual migration notes are located in the sub-repos and sorted by repository.

![image](https://github.com/ros-controls/control.ros.org/assets/3367244/588d331c-487b-4be1-8443-bc12ffe18080)
