### PR TITLE
Add API page

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -85,8 +85,7 @@ extensions = [
     "sphinx_copybutton",
     "generate_parameter_library",
     'sphinx_tabs.tabs',
-    "sphinx.ext.autosectionlabel",
-    "breathe"
+    "sphinx.ext.autosectionlabel"
 ]
 
 # Make sure the target is unique

--- a/conf.py
+++ b/conf.py
@@ -86,6 +86,7 @@ extensions = [
     "generate_parameter_library",
     'sphinx_tabs.tabs',
     "sphinx.ext.autosectionlabel",
+    "breathe"
 ]
 
 # Make sure the target is unique

--- a/doc/api/api.rst
+++ b/doc/api/api.rst
@@ -8,7 +8,7 @@ Here you can find links to the API documentation published on docs.ros.org
 ros2_control
 *************
 
-A documentation for the whole repository is parsed by doxygen and can be found `here <../../api/index.html>`_
+A documentation for the whole repository is parsed by doxygen and can be found `here <../api/index.html>`_
 
 .. list-table::
   :header-rows: 1

--- a/doc/api/api.rst
+++ b/doc/api/api.rst
@@ -3,42 +3,152 @@
 API Documentation
 =================
 
+Here you can find links to the API documentation published on docs.ros.org
+
 ros2_control
 *************
-API documentation is parsed by doxygen and can be found `here <../../api/index.html>`_
+
+A documentation for the whole repository is parsed by doxygen and can be found `here <../../api/index.html>`_
+
+.. list-table::
+  :header-rows: 1
+
+  * - Package Name
+    - API
+    - ROS Index
+  * - controller_interface
+    - `API <http://docs.ros.org/en/{DISTRO}/p/controller_interface/>`__
+    - `ROS Index <https://index.ros.org/p/controller_interface/#{DISTRO}>`__
+  * - controller_manager
+    - `API <http://docs.ros.org/en/{DISTRO}/p/controller_manager/>`__
+    - `ROS Index <https://index.ros.org/p/controller_manager/#{DISTRO}>`__
+  * - controller_manager_msgs
+    - `API <http://docs.ros.org/en/{DISTRO}/p/controller_manager_msgs/>`__
+    - `ROS Index <https://index.ros.org/p/controller_manager_msgs/#{DISTRO}>`__
+  * - hardware_interface
+    - `API <http://docs.ros.org/en/{DISTRO}/p/hardware_interface/>`__
+    - `ROS Index <https://index.ros.org/p/hardware_interface/#{DISTRO}>`__
+  * - ros2_control_test_assets
+    - `API <http://docs.ros.org/en/{DISTRO}/p/ros2_control_test_assets/>`__
+    - `ROS Index <https://index.ros.org/p/ros2_control/ros2_control_test_assets/#{DISTRO}>`__
+  * - transmission_interface
+    - `API <http://docs.ros.org/en/{DISTRO}/p/transmission_interface/>`__
+    - `ROS Index <https://index.ros.org/p/transmission_interface/#{DISTRO}>`__
+
+ros2_controllers
+****************
+
+.. list-table::
+  :header-rows: 1
+
+  * - Package Name
+    - API
+    - ROS Index
+  * - ackermann_steering_controller
+    - `API <http://docs.ros.org/en/{DISTRO}/p/ackermann_steering_controller/>`__
+    - `ROS Index <https://index.ros.org/p/ackermann_steering_controller/#{DISTRO}>`__
+  * - admittance_controller
+    - `API <http://docs.ros.org/en/{DISTRO}/p/admittance_controller/>`__
+    - `ROS Index <https://index.ros.org/p/admittance_controller/#{DISTRO}>`__
+  * - bicycle_steering_controller
+    - `API <http://docs.ros.org/en/{DISTRO}/p/bicycle_steering_controller/>`__
+    - `ROS Index <https://index.ros.org/p/bicycle_steering_controller/#{DISTRO}>`__
+  * - diff_drive_controller
+    - `API <http://docs.ros.org/en/{DISTRO}/p/diff_drive_controller/>`__
+    - `ROS Index <https://index.ros.org/p/diff_drive_controller/#{DISTRO}>`__
+  * - effort_controllers
+    - `API <http://docs.ros.org/en/{DISTRO}/p/effort_controllers/>`__
+    - `ROS Index <https://index.ros.org/p/effort_controllers/#{DISTRO}>`__
+  * - force_torque_sensor_broadcaster
+    - `API <http://docs.ros.org/en/{DISTRO}/p/force_torque_sensor_broadcaster/>`__
+    - `ROS Index <https://index.ros.org/p/force_torque_sensor_broadcaster/#{DISTRO}>`__
+  * - forward_command_controller
+    - `API <http://docs.ros.org/en/{DISTRO}/p/forward_command_controller/>`__
+    - `ROS Index <https://index.ros.org/p/forward_command_controller/#{DISTRO}>`__
+  * - imu_sensor_broadcaster
+    - `API <http://docs.ros.org/en/{DISTRO}/p/imu_sensor_broadcaster/>`__
+    - `ROS Index <https://index.ros.org/p/imu_sensor_broadcaster/#{DISTRO}>`__
+  * - joint_state_broadcaster
+    - `API <http://docs.ros.org/en/{DISTRO}/p/joint_state_broadcaster/>`__
+    - `ROS Index <https://index.ros.org/p/joint_state_broadcaster/#{DISTRO}>`__
+  * - joint_trajectory_controller
+    - `API <http://docs.ros.org/en/{DISTRO}/p/joint_trajectory_controller/>`__
+    - `ROS Index <https://index.ros.org/p/joint_trajectory_controller/#{DISTRO}>`__
+  * - pid_controller
+    - `API <http://docs.ros.org/en/{DISTRO}/p/pid_controller/>`__
+    - `ROS Index <https://index.ros.org/p/pid_controller/#{DISTRO}>`__
+  * - position_controllers
+    - `API <http://docs.ros.org/en/{DISTRO}/p/position_controllers/>`__
+    - `ROS Index <https://index.ros.org/p/position_controllers/#{DISTRO}>`__
+  * - range_sensor_broadcaster
+    - `API <http://docs.ros.org/en/{DISTRO}/p/range_sensor_broadcaster/>`__
+    - `ROS Index <https://index.ros.org/p/range_sensor_broadcaster/#{DISTRO}>`__
+  * - steering_controllers_library
+    - `API <http://docs.ros.org/en/{DISTRO}/p/steering_controllers_library/>`__
+    - `ROS Index <https://index.ros.org/p/steering_controllers_library/#{DISTRO}>`__
+  * - tricycle_controller
+    - `API <http://docs.ros.org/en/{DISTRO}/p/tricycle_controller/>`__
+    - `ROS Index <https://index.ros.org/p/tricycle_controller/#{DISTRO}>`__
+  * - tricycle_steering_controller
+    - `API <http://docs.ros.org/en/{DISTRO}/p/tricycle_steering_controller/>`__
+    - `ROS Index <https://index.ros.org/p/tricycle_steering_controller/#{DISTRO}>`__
+  * - velocity_controllers
+    - `API <http://docs.ros.org/en/{DISTRO}/p/velocity_controllers/>`__
+    - `ROS Index <https://index.ros.org/p/velocity_controllers/#{DISTRO}>`__
 
 control_msgs
-***************
+*************
 
-.. toctree::
-   :maxdepth: 2
+.. list-table::
+   :header-rows: 1
 
-   Message Definitions <../control_msgs/generated/message_definitions>
-   Service Definitions <../control_msgs/generated/service_definitions>
-   Action Definitions <../control_msgs/generated/action_definitions>
+   * - Package Name
+     - API
+     - ROS Index
+   * - control_msgs
+     - `API <http://docs.ros.org/en/{DISTRO}/p/control_msgs/>`__
+     - `ROS Index <https://index.ros.org/p/control_msgs/#{DISTRO}>`__
 
 control_toolbox
 ***************
 
-.. toctree::
-   :maxdepth: 2
+.. list-table::
+   :header-rows: 1
 
-   C++ API <../control_toolbox/generated/index>
-   Service Definitions <../control_toolbox/generated/service_definitions>
+   * - Package Name
+     - API
+     - ROS Index
+   * - control_toolbox
+     - `API <http://docs.ros.org/en/{DISTRO}/p/control_toolbox/>`__
+     - `ROS Index <https://index.ros.org/p/control_toolbox/#{DISTRO}>`__
 
-realtime_tools
-***************
-
-.. toctree::
-   :maxdepth: 2
-
-   C++ API <../realtime_tools/index>
 
 kinematics_interface
 ********************
 
-.. toctree::
-   :maxdepth: 2
+.. list-table::
+   :header-rows: 1
 
-   C++ API kinematics_interface <../kinematics_interface/index>
-   C++ API kinematics_interface_kdl <../kinematics_interface_kdl/index>
+   * - Package Name
+     - API
+     - ROS Index
+   * - kinematics_interface
+     - `API <http://docs.ros.org/en/{DISTRO}/p/kinematics_interface/>`__
+     - `ROS Index <https://index.ros.org/p/kinematics_interface/#{DISTRO}>`__
+   * - kinematics_interface_kdl
+     - `API <http://docs.ros.org/en/{DISTRO}/p/kinematics_interface_kdl/>`__
+     - `ROS Index <https://index.ros.org/p/kinematics_interface_kdl/#{DISTRO}>`__
+
+
+realtime_tools
+**************
+
+.. list-table::
+   :header-rows: 1
+
+   * - Package Name
+     - API
+     - ROS Index
+   * - control_msgs
+     - `API <http://docs.ros.org/en/{DISTRO}/p/realtime_tools/>`__
+     - `ROS Index <https://index.ros.org/p/velocity_controllers/#{DISTRO}>`__

--- a/doc/api/api.rst
+++ b/doc/api/api.rst
@@ -18,22 +18,22 @@ A documentation for the whole repository is parsed by doxygen and can be found `
     - ROS Index
   * - controller_interface
     - `API <http://docs.ros.org/en/{DISTRO}/p/controller_interface/>`__
-    - `ROS Index <https://index.ros.org/p/controller_interface/#{DISTRO}>`__
+    - `ROS Index <https://index.ros.org/p/controller_interface/>`__
   * - controller_manager
     - `API <http://docs.ros.org/en/{DISTRO}/p/controller_manager/>`__
-    - `ROS Index <https://index.ros.org/p/controller_manager/#{DISTRO}>`__
+    - `ROS Index <https://index.ros.org/p/controller_manager/>`__
   * - controller_manager_msgs
     - `API <http://docs.ros.org/en/{DISTRO}/p/controller_manager_msgs/>`__
-    - `ROS Index <https://index.ros.org/p/controller_manager_msgs/#{DISTRO}>`__
+    - `ROS Index <https://index.ros.org/p/controller_manager_msgs/>`__
   * - hardware_interface
     - `API <http://docs.ros.org/en/{DISTRO}/p/hardware_interface/>`__
-    - `ROS Index <https://index.ros.org/p/hardware_interface/#{DISTRO}>`__
+    - `ROS Index <https://index.ros.org/p/hardware_interface/>`__
   * - ros2_control_test_assets
     - `API <http://docs.ros.org/en/{DISTRO}/p/ros2_control_test_assets/>`__
-    - `ROS Index <https://index.ros.org/p/ros2_control/ros2_control_test_assets/#{DISTRO}>`__
+    - `ROS Index <https://index.ros.org/p/ros2_control_test_assets/>`__
   * - transmission_interface
     - `API <http://docs.ros.org/en/{DISTRO}/p/transmission_interface/>`__
-    - `ROS Index <https://index.ros.org/p/transmission_interface/#{DISTRO}>`__
+    - `ROS Index <https://index.ros.org/p/transmission_interface/>`__
 
 ros2_controllers
 ****************
@@ -46,55 +46,55 @@ ros2_controllers
     - ROS Index
   * - ackermann_steering_controller
     - `API <http://docs.ros.org/en/{DISTRO}/p/ackermann_steering_controller/>`__
-    - `ROS Index <https://index.ros.org/p/ackermann_steering_controller/#{DISTRO}>`__
+    - `ROS Index <https://index.ros.org/p/ackermann_steering_controller/>`__
   * - admittance_controller
     - `API <http://docs.ros.org/en/{DISTRO}/p/admittance_controller/>`__
-    - `ROS Index <https://index.ros.org/p/admittance_controller/#{DISTRO}>`__
+    - `ROS Index <https://index.ros.org/p/admittance_controller/>`__
   * - bicycle_steering_controller
     - `API <http://docs.ros.org/en/{DISTRO}/p/bicycle_steering_controller/>`__
-    - `ROS Index <https://index.ros.org/p/bicycle_steering_controller/#{DISTRO}>`__
+    - `ROS Index <https://index.ros.org/p/bicycle_steering_controller/>`__
   * - diff_drive_controller
     - `API <http://docs.ros.org/en/{DISTRO}/p/diff_drive_controller/>`__
-    - `ROS Index <https://index.ros.org/p/diff_drive_controller/#{DISTRO}>`__
+    - `ROS Index <https://index.ros.org/p/diff_drive_controller/>`__
   * - effort_controllers
     - `API <http://docs.ros.org/en/{DISTRO}/p/effort_controllers/>`__
-    - `ROS Index <https://index.ros.org/p/effort_controllers/#{DISTRO}>`__
+    - `ROS Index <https://index.ros.org/p/effort_controllers/>`__
   * - force_torque_sensor_broadcaster
     - `API <http://docs.ros.org/en/{DISTRO}/p/force_torque_sensor_broadcaster/>`__
-    - `ROS Index <https://index.ros.org/p/force_torque_sensor_broadcaster/#{DISTRO}>`__
+    - `ROS Index <https://index.ros.org/p/force_torque_sensor_broadcaster/>`__
   * - forward_command_controller
     - `API <http://docs.ros.org/en/{DISTRO}/p/forward_command_controller/>`__
-    - `ROS Index <https://index.ros.org/p/forward_command_controller/#{DISTRO}>`__
+    - `ROS Index <https://index.ros.org/p/forward_command_controller/>`__
   * - imu_sensor_broadcaster
     - `API <http://docs.ros.org/en/{DISTRO}/p/imu_sensor_broadcaster/>`__
-    - `ROS Index <https://index.ros.org/p/imu_sensor_broadcaster/#{DISTRO}>`__
+    - `ROS Index <https://index.ros.org/p/imu_sensor_broadcaster/>`__
   * - joint_state_broadcaster
     - `API <http://docs.ros.org/en/{DISTRO}/p/joint_state_broadcaster/>`__
-    - `ROS Index <https://index.ros.org/p/joint_state_broadcaster/#{DISTRO}>`__
+    - `ROS Index <https://index.ros.org/p/joint_state_broadcaster/>`__
   * - joint_trajectory_controller
     - `API <http://docs.ros.org/en/{DISTRO}/p/joint_trajectory_controller/>`__
-    - `ROS Index <https://index.ros.org/p/joint_trajectory_controller/#{DISTRO}>`__
+    - `ROS Index <https://index.ros.org/p/joint_trajectory_controller/>`__
   * - pid_controller
     - `API <http://docs.ros.org/en/{DISTRO}/p/pid_controller/>`__
-    - `ROS Index <https://index.ros.org/p/pid_controller/#{DISTRO}>`__
+    - `ROS Index <https://index.ros.org/p/pid_controller/>`__
   * - position_controllers
     - `API <http://docs.ros.org/en/{DISTRO}/p/position_controllers/>`__
-    - `ROS Index <https://index.ros.org/p/position_controllers/#{DISTRO}>`__
+    - `ROS Index <https://index.ros.org/p/position_controllers/>`__
   * - range_sensor_broadcaster
     - `API <http://docs.ros.org/en/{DISTRO}/p/range_sensor_broadcaster/>`__
-    - `ROS Index <https://index.ros.org/p/range_sensor_broadcaster/#{DISTRO}>`__
+    - `ROS Index <https://index.ros.org/p/range_sensor_broadcaster/>`__
   * - steering_controllers_library
     - `API <http://docs.ros.org/en/{DISTRO}/p/steering_controllers_library/>`__
-    - `ROS Index <https://index.ros.org/p/steering_controllers_library/#{DISTRO}>`__
+    - `ROS Index <https://index.ros.org/p/steering_controllers_library/>`__
   * - tricycle_controller
     - `API <http://docs.ros.org/en/{DISTRO}/p/tricycle_controller/>`__
-    - `ROS Index <https://index.ros.org/p/tricycle_controller/#{DISTRO}>`__
+    - `ROS Index <https://index.ros.org/p/tricycle_controller/>`__
   * - tricycle_steering_controller
     - `API <http://docs.ros.org/en/{DISTRO}/p/tricycle_steering_controller/>`__
-    - `ROS Index <https://index.ros.org/p/tricycle_steering_controller/#{DISTRO}>`__
+    - `ROS Index <https://index.ros.org/p/tricycle_steering_controller/>`__
   * - velocity_controllers
     - `API <http://docs.ros.org/en/{DISTRO}/p/velocity_controllers/>`__
-    - `ROS Index <https://index.ros.org/p/velocity_controllers/#{DISTRO}>`__
+    - `ROS Index <https://index.ros.org/p/velocity_controllers/>`__
 
 control_msgs
 *************
@@ -107,7 +107,7 @@ control_msgs
      - ROS Index
    * - control_msgs
      - `API <http://docs.ros.org/en/{DISTRO}/p/control_msgs/>`__
-     - `ROS Index <https://index.ros.org/p/control_msgs/#{DISTRO}>`__
+     - `ROS Index <https://index.ros.org/p/control_msgs/>`__
 
 control_toolbox
 ***************
@@ -120,7 +120,7 @@ control_toolbox
      - ROS Index
    * - control_toolbox
      - `API <http://docs.ros.org/en/{DISTRO}/p/control_toolbox/>`__
-     - `ROS Index <https://index.ros.org/p/control_toolbox/#{DISTRO}>`__
+     - `ROS Index <https://index.ros.org/p/control_toolbox/>`__
 
 
 kinematics_interface
@@ -134,10 +134,10 @@ kinematics_interface
      - ROS Index
    * - kinematics_interface
      - `API <http://docs.ros.org/en/{DISTRO}/p/kinematics_interface/>`__
-     - `ROS Index <https://index.ros.org/p/kinematics_interface/#{DISTRO}>`__
+     - `ROS Index <https://index.ros.org/p/kinematics_interface/>`__
    * - kinematics_interface_kdl
      - `API <http://docs.ros.org/en/{DISTRO}/p/kinematics_interface_kdl/>`__
-     - `ROS Index <https://index.ros.org/p/kinematics_interface_kdl/#{DISTRO}>`__
+     - `ROS Index <https://index.ros.org/p/kinematics_interface_kdl/>`__
 
 
 realtime_tools
@@ -151,4 +151,4 @@ realtime_tools
      - ROS Index
    * - control_msgs
      - `API <http://docs.ros.org/en/{DISTRO}/p/realtime_tools/>`__
-     - `ROS Index <https://index.ros.org/p/velocity_controllers/#{DISTRO}>`__
+     - `ROS Index <https://index.ros.org/p/velocity_controllers/>`__

--- a/doc/api/api.rst
+++ b/doc/api/api.rst
@@ -1,0 +1,44 @@
+
+=================
+API Documentation
+=================
+
+ros2_control
+*************
+API documentation is parsed by doxygen and can be found `here <../../api/index.html>`_
+
+control_msgs
+***************
+
+.. toctree::
+   :maxdepth: 2
+
+   Message Definitions <../control_msgs/generated/message_definitions>
+   Service Definitions <../control_msgs/generated/service_definitions>
+   Action Definitions <../control_msgs/generated/action_definitions>
+
+control_toolbox
+***************
+
+.. toctree::
+   :maxdepth: 2
+
+   C++ API <../control_toolbox/generated/index>
+   Service Definitions <../control_toolbox/generated/service_definitions>
+
+realtime_tools
+***************
+
+.. toctree::
+   :maxdepth: 2
+
+   C++ API <../realtime_tools/index>
+
+kinematics_interface
+********************
+
+.. toctree::
+   :maxdepth: 2
+
+   C++ API kinematics_interface <../kinematics_interface/index>
+   C++ API kinematics_interface_kdl <../kinematics_interface_kdl/index>

--- a/index.rst
+++ b/index.rst
@@ -13,6 +13,7 @@ Welcome to the ros2_control documentation!
    doc/ros2_control/ros2controlcli/doc/userdoc.rst
    doc/simulators/simulators.rst
    doc/migration/migration.rst
+   doc/api/api.rst
    doc/supported_robots/supported_robots.rst
    doc/resources/resources.rst
    doc/contributing/contributing.rst
@@ -35,6 +36,7 @@ The ros2_control framework consists of the following Github repositories:
 * `control_toolbox`_ - some widely-used control theory implementations (e.g. PID) used by controllers;
 * `realtime_tools`_ - general toolkit for realtime support, e.g., realtime buffers and publishers;
 * `control_msgs`_ - common messages.
+* `kinematics_interface`_ - for using C++ kinematics frameworks.
 
 
 Additionally, there are following (unreleased) packages are relevant for getting-started and project management:
@@ -72,6 +74,7 @@ General discussions
 .. _control_msgs: https://github.com/ros-controls/control_msgs
 .. _realtime_tools: https://github.com/ros-controls/realtime_tools
 .. _control_toolbox: https://github.com/ros-controls/control_toolbox
+.. _kinematics_interface: https://github.com/ros-controls/kinematics_interface
 .. _ros2_control_demos: https://github.com/ros-controls/ros2_control_demos
 .. _controller_manager_msgs: https://github.com/ros-controls/ros2_control/tree/{REPOS_FILE_BRANCH}/controller_manager_msgs
 .. _Controller Manager: https://github.com/ros-controls/ros2_control/blob/{REPOS_FILE_BRANCH}/controller_manager/src/controller_manager.cpp


### PR DESCRIPTION
I'd like to include the API documentation of all packages, also for the utilities like control_toolbox etc.

I see two options:

1. Make a table and just link to docs.ros.org like [here](http://docs.ros.org/en/rolling/p/realtime_tools/). It will be a bit more visible than now, but not searchable from control.ros.org
2. ~~Let rosdoc2 create the pages manually and publish a selection on control.ros.org. Advantage (or maybe also disadvantage?): Everything can be found from within a single search prompt.~~

The majority was for option 1 during the WG meeting on April 10th. I changed it now to a simple table:

![image](https://github.com/ros-controls/control.ros.org/assets/3367244/9ea34d0c-11a0-4112-b91a-b59655c2cc82)

