### PR TITLE
Fix compilation instructions again

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -43,8 +43,7 @@ You can choose between the following options:
 
           mkdir -p ~/ros2_ws/src
           cd ~/ros2_ws/
-          wget https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/ros_controls.$ROS_DISTRO.repos
-          vcs import src < ros_controls.$ROS_DISTRO.repos
+          vcs import --input https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/ros_controls.$ROS_DISTRO.repos src
 
     .. group-tab:: Development version
 
@@ -52,8 +51,7 @@ You can choose between the following options:
 
           mkdir -p ~/ros2_ws/src
           cd ~/ros2_ws/
-          wget https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/ros_controls.rolling-on-$ROS_DISTRO.repos.repos
-          vcs import src < ros_controls.$ROS_DISTRO.repos
+          vcs import --input https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/ros_controls.rolling-on-$ROS_DISTRO.repos src
 
 * Install dependencies:
 


### PR DESCRIPTION
- Fix the development version instructions (2x the wrong filename)
- use `vcs import --input` instead of `wget`