### PR TITLE
Use a single file for migration + release notes

### DIFF
--- a/doc/migration/migration.rst
+++ b/doc/migration/migration.rst
@@ -14,22 +14,11 @@ Coming from ros_control (ROS 1)
 Between different ROS 2 distributions
 **************************************
 
-These lists summarizes necessary changes to your code for a version update. For non-breaking updates, see the :ref:`release_notes`.
+This list summarizes necessary changes to your code for a version update from Iron to Jazzy. For non-breaking updates, see the :ref:`release_notes`.
 
-ros2_control
--------------
 
 .. toctree::
    :titlesonly:
 
-   Foxy to Galactic <../ros2_control/doc/migration/Galactic.rst>
-   Iron to Jazzy <../ros2_control/doc/migration/Jazzy.rst>
-
-
-ros2_controllers
-----------------
-
-.. toctree::
-   :titlesonly:
-
-   Iron to Jazzy <../ros2_controllers/doc/migration/Jazzy.rst>
+   ros2_control <../ros2_control/doc/migration.rst>
+   ros2_controllers <../ros2_controllers/doc/migration.rst>

--- a/doc/migration/migration.rst
+++ b/doc/migration/migration.rst
@@ -14,7 +14,9 @@ Coming from ros_control (ROS 1)
 Between different ROS 2 distributions
 **************************************
 
-This list summarizes necessary changes to your code for a version update to {DISTRO}. For non-breaking updates, see the :ref:`release_notes`.
+This list summarizes necessary changes to your code for a version update to {DISTRO}. If you are skipping a distribution update, make sure to read the migration guides of all intermediate distributions.
+
+For non-breaking updates, see the :ref:`release_notes`.
 
 
 .. toctree::

--- a/doc/migration/migration.rst
+++ b/doc/migration/migration.rst
@@ -14,7 +14,7 @@ Coming from ros_control (ROS 1)
 Between different ROS 2 distributions
 **************************************
 
-This list summarizes necessary changes to your code for a version update from Iron to Jazzy. For non-breaking updates, see the :ref:`release_notes`.
+This list summarizes necessary changes to your code for a version update to {DISTRO}. For non-breaking updates, see the :ref:`release_notes`.
 
 
 .. toctree::

--- a/doc/release_notes/release_notes.rst
+++ b/doc/release_notes/release_notes.rst
@@ -9,19 +9,11 @@ These lists might not be complete, see the ``CHANGELOG.rst`` files in the respec
 
 For necessary changes to your code for a version update, see the :ref:`migration`.
 
-ros2_control
+Iron to Jazzy
 -------------
 
 .. toctree::
    :titlesonly:
 
-   Iron to Jazzy <../ros2_control/doc/release_notes/Jazzy.rst>
-
-
-ros2_controllers
-----------------
-
-.. toctree::
-   :titlesonly:
-
-   Iron to Jazzy <../ros2_controllers/doc/release_notes/Jazzy.rst>
+   ros2_control <../ros2_control/doc/release_notes.rst>
+   ros2_controllers <../ros2_controllers/doc/release_notes.rst>

--- a/doc/release_notes/release_notes.rst
+++ b/doc/release_notes/release_notes.rst
@@ -3,14 +3,12 @@
 Release Notes
 =================================
 
-This page should highlight the most important changes of the ros2_control framework.
+This page should highlight the most important changes of the ros2_control framework in the {DISTRO} release.
 
 These lists might not be complete, see the ``CHANGELOG.rst`` files in the respective repositories for a full list of changes.
 
 For necessary changes to your code for a version update, see the :ref:`migration`.
 
-Iron to Jazzy
--------------
 
 .. toctree::
    :titlesonly:

--- a/doc/release_notes/release_notes.rst
+++ b/doc/release_notes/release_notes.rst
@@ -3,7 +3,7 @@
 Release Notes
 =================================
 
-This page should highlight the most important changes of the ros2_control framework in the {DISTRO} release.
+This page should highlight the most important changes of the ros2_control framework in the {DISTRO} release. If you are skipping a distribution update, make sure to read the release notes of all intermediate distributions.
 
 These lists might not be complete, see the ``CHANGELOG.rst`` files in the respective repositories for a full list of changes.
 


### PR DESCRIPTION
we decided to show only the notes for the respective version in the docs, instead of all incremental distro upgrades
# migration
![image](https://github.com/user-attachments/assets/f0ae9702-ca85-4076-8033-f387f34030f5)

# release
![image](https://github.com/user-attachments/assets/4696e0fd-9c01-44f8-94c7-83551cc732f0)

