### PR TITLE
Mark iron EOL and remove it from workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,4 +24,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "iron"
+    target-branch: "jazzy"

--- a/.github/workflows/sphinx-check-links.yml
+++ b/.github/workflows/sphinx-check-links.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        BRANCH: [humble, iron, jazzy, rolling]
+        BRANCH: [humble, jazzy, rolling]
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/sphinx-check-page-multiversion.yml
+++ b/.github/workflows/sphinx-check-page-multiversion.yml
@@ -9,7 +9,6 @@ on:
         type: choice
         options:
         - humble
-        - iron
         - jazzy
         - rolling
   pull_request:

--- a/.github/workflows/sphinx-check-warnings.yml
+++ b/.github/workflows/sphinx-check-warnings.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        BRANCH: [humble, iron, jazzy, rolling]
+        BRANCH: [humble, jazzy, rolling]
     steps:
     - uses: actions/checkout@v4
       with:

--- a/conf.py
+++ b/conf.py
@@ -205,8 +205,8 @@ else:
 smv_branch_whitelist = r"^(foxy|galactic|humble|iron|jazzy|"+ base_branch + r")$"
 smv_released_pattern = r"^refs/(heads|remotes/[^/]+)/(foxy|galactic|humble|iron).*$"
 smv_remote_whitelist = r"^(origin)$"
-smv_latest_version = "iron"
-smv_eol_versions = ["foxy", "galactic"]
+smv_latest_version = "jazzy"
+smv_eol_versions = ["foxy", "galactic", "iron"]
 
 distro_full_names = {
     "foxy": "Foxy Fitzroy",

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -15,16 +15,16 @@ To use it, you have to install ``ros-{DISTRO}-ros2-control`` and ``ros-{DISTRO}-
 Building from Source
 ---------------------------
 
-The rolling branch is compatible with both Humble and Iron ROS distributions. You can find more information about this compatibility on the respective `Humble <https://control.ros.org/humble/doc/getting_started/getting_started.html#building-from-source>`__ and `Iron <https://control.ros.org/iron/doc/getting_started/getting_started.html#building-from-source>`__ versions of this page.
+The rolling branch is compatible with both Humble and Jazzy ROS distributions. You can find more information about this compatibility on the respective `Humble <https://control.ros.org/humble/doc/getting_started/getting_started.html#building-from-source>`__ and `Jazzy <https://control.ros.org/jazzy/doc/getting_started/getting_started.html#building-from-source>`__ versions of this page.
 
 .. raw:: html
 
     <a href="https://github.com/ros-controls/ros2_control_ci/actions/workflows/{DISTRO}-binary-build.yml">
         <img src="https://github.com/ros-controls/ros2_control_ci/actions/workflows/{DISTRO}-binary-build.yml/badge.svg" alt="{DISTRO} Binary Build"/></a></br>
-    <a href="https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-compatibility-iron-binary-build.yml">
-        <img src="https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-compatibility-iron-binary-build.yml/badge.svg" alt="Rolling Compatibility iron"/></a>
+    <a href="https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-compatibility-jazzy-binary-build.yml">
+        <img src="https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-compatibility-jazzy-binary-build.yml/badge.svg" alt="Rolling Compatibility Jazzy"/></a>
     <a href="https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-compatibility-humble-binary-build.yml">
-        <img src="https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-compatibility-humble-binary-build.yml/badge.svg" alt="Rolling Compatibility humble"/></a>
+        <img src="https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-compatibility-humble-binary-build.yml/badge.svg" alt="Rolling Compatibility Humble"/></a>
 
 If you want to install the framework from source, e.g., for contributing to the framework, use the following commands:
 


### PR DESCRIPTION
Due after the next patch release on November 15th.
