### PR TITLE
Update to linkchecker

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -172,6 +172,14 @@ html_logo = "images/logo_ros-controls.png"
 
 github_url = "https://github.com/ros-controls/control.ros.org"
 
+# -- linkchecker options -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#filtering
+linkcheck_anchors_ignore_for_url = [
+    'https://github.com/',
+    'https://index.ros.org/'
+    ]
+linkcheck_ignore = [r'https://gazebosim.org/home']
+
 # -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.

--- a/make_help_scripts/check_links.py
+++ b/make_help_scripts/check_links.py
@@ -50,7 +50,7 @@ def main():
     # Check for broken links
     with open(LOGFILE, "r") as logfile:
         broken_links = [
-            line for line in logfile if "broken" in line and "github" not in line and "vimeo" not in line]
+          line for line in logfile if 'broken' in line]
 
     if broken_links:
         num_broken = len(broken_links)


### PR DESCRIPTION
* Don't check gazebosim.org 404 error
* use linkcheck_anchors_ignore_for_url for github instead of ignoring it

Linkcheck should fail now until https://github.com/ros-controls/ros2_control_demos/pull/645 is merged