### PR TITLE
Add governance page

### DIFF
--- a/doc/governance/governance.rst
+++ b/doc/governance/governance.rst
@@ -1,0 +1,124 @@
+
+.. _Governance:
+
+Project Governance
+==================
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+Since 2022, the ros-controls project has been governed by the `Open Source Robotics Alliance (OSRA) <https://osralliance.org/>`__.
+The information below is meant to give a quick overview of the project governance, but for full information please see `the OSRA's website <https://osralliance.org/how-it-works/>`__.
+
+The ros-controls Project Management Committee is responsible for the day-to-day operations of the ros-controls project.
+The ros-controls PMC consists of the Project Leader, the ros-controls PMC Members (who have full voting rights), a Supporting Individual Representative, and the Chair of the TGC.
+The project also has Committers, who help manage one or more repositories but are not a part of the PMC.
+The Project Leader, all PMC Members, and all Committers are chosen on a meritocratic basis.
+
+The day-to-day operations of the ros-controls PMC include managing the members and committers, managing the repositories that make up ros-controls, reviewing and merging code from the ros-controls community, maintaining the repositories, and making technical decisions that decide the direction of the project.
+
+For more details about the ros-controls PMC, please see the `Charter for the ros-controls Project <https://github.com/openrobotics/osra-policies-and-procedures/pull/7>`__.
+
+Current ros-controls PMC Constituents
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ros-controls PMC currently consists of the following constituents:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - Affiliation
+     - GitHub handle
+     - PMC role
+     - Time Zone (optional)
+   * - Bence Maygar
+     - `Locus Robotics <https://locusrobotics.com/>`_
+     - `bmagyar <https://github.com/bmagyar>`_
+     - Project Leader
+     - GMT (UTC+0)
+   * - Denis Stogl
+     - `b»robotized <https://www.b-robotized.com/>`_
+     - `destogl <https://github.com/destogl>`_
+     - Project Co-Leader
+     - CET (UTC+1)/CEST (UTC+2)
+   * - Christoph Fröhlich
+     - `AIT - Austrian Institute of Technology GmbH <https://www.ait.ac.at/>`_
+     - `christophfroehlich <https://github.com/christophfroehlich>`_
+     - Member
+     - CET (UTC+1)/CEST (UTC+2)
+   * -  Sai Kishor Kothakota
+     - `PAL Robotics S.L <https://pal-robotics.com/>`_
+     - `saikishor <https://github.com/saikishor>`_
+     - Member
+     - CET (UTC+1)/CEST (UTC+2)
+
+Current ros-controls Committers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ros-controls committers (who are not also part of the ros-controls PMC) consists of the following constituents:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - Affiliation
+     - GitHub handle
+     - Time Zone (optional)
+   * - Alejandro Hernandez Cordero
+     - `Honu Robotics <https://www.honurobotics.com/>`_
+     - `ahcorde <https://github.com/ahcorde>`_
+     - CET (UTC+1)/CEST (UTC+2)
+
+Past ros-controls PMC Constituents
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ros-controls PMC thanks the following past constituents for their service:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - PMC role
+     - GitHub handle (optional)
+   * - None yet
+     - None yet
+     - None yet
+
+Repositories managed by the ros-controls PMC
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following repositories are managed by the ros-controls PMC:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Repository URL
+     - Committers
+   * - https://github.com/ros-controls/ros2_control
+     - Not Yet Available
+   * - https://github.com/ros-controls/ros2_controllers
+     - Not Yet Available
+   * - https://github.com/ros-controls/ros2_control_cmake
+     - Not Yet Available
+   * - https://github.com/ros-controls/ros2_control_ci
+     - Not Yet Available
+   * - https://github.com/ros-controls/ros2_control_demos
+     - Not Yet Available
+   * - https://github.com/ros-controls/control_msgs
+     - Not Yet Available
+   * - https://github.com/ros-controls/control_toolbox
+     - Not Yet Available
+   * - https://github.com/ros-controls/control.ros.org
+     - Not Yet Available
+   * - https://github.com/ros-controls/gz_ros2_control
+     - Not Yet Available
+   * - https://github.com/ros-controls/kinematics_interface
+     - Not Yet Available
+   * - https://github.com/ros-controls/realtime_tools
+     - Not Yet Available
+   * - https://github.com/ros-controls/ros2_rhel
+     - Not Yet Available
+   * - https://github.com/ros-controls/ros2_debian
+     - Not Yet Available

--- a/doc/governance/governance.rst
+++ b/doc/governance/governance.rst
@@ -8,7 +8,7 @@ Project Governance
    :depth: 2
    :local:
 
-Since 2022, the ros-controls project has been governed by the `Open Source Robotics Alliance (OSRA) <https://osralliance.org/>`__.
+Since 2025, the ros-controls project has been governed by the `Open Source Robotics Alliance (OSRA) <https://osralliance.org/>`__.
 The information below is meant to give a quick overview of the project governance, but for full information please see `the OSRA's website <https://osralliance.org/how-it-works/>`__.
 
 The ros-controls Project Management Committee is responsible for the day-to-day operations of the ros-controls project.

--- a/doc/governance/governance.rst
+++ b/doc/governance/governance.rst
@@ -113,7 +113,7 @@ The following repositories are managed by the ros-controls PMC:
    * - https://github.com/ros-controls/control.ros.org
      - Not Yet Available
    * - https://github.com/ros-controls/gz_ros2_control
-     - Not Yet Available
+     - Alejandro Hernandez Cordero
    * - https://github.com/ros-controls/kinematics_interface
      - Not Yet Available
    * - https://github.com/ros-controls/realtime_tools

--- a/index.rst
+++ b/index.rst
@@ -19,6 +19,7 @@ Welcome to the ros2_control documentation!
    doc/supported_robots/supported_robots.rst
    doc/resources/resources.rst
    doc/contributing/contributing.rst
+   doc/governance/governance.rst
    doc/project_ideas.rst
    doc/acknowledgements/acknowledgements.rst
 

--- a/index.rst
+++ b/index.rst
@@ -62,7 +62,7 @@ Questions
 PMC Meeting
    Every second Wednesday there is a PMC meeting.
    To join the meeting check the announcement on `ROS Discourse`_.
-   You can joint the meeting through `google groups <https://groups.google.com/forum/#!forum/ros-control-working-group-invites>`_ or directly on Zoom (check the announcement).
+   You can join the meeting through `google groups <https://groups.google.com/forum/#!forum/ros-control-working-group-invites>`_ or directly on Zoom (check the announcement).
    To propose new discussion points, or review notes from previous meetings, check `this document <https://docs.google.com/document/d/1818AoYucI2z82awL_-8sAA5pMCV_g_wXCJiM6SQmhSQ/edit?usp=sharing>`_.
 
 Projects

--- a/index.rst
+++ b/index.rst
@@ -53,14 +53,16 @@ Additionally, the following (unreleased) packages are relevant for documentation
 
 Development Organisation and Communication
 -------------------------------------------
+OSRA
+   The ros-controls project is governed by the `Open Source Robotics Alliance (OSRA) <https://osralliance.org/>`__. See :ref:`Governance` for more details.
 
 Questions
    Please use `Robotics Stack Exchange <https://robotics.stackexchange.com>`_ and tag your questions with ``ros2_control``.
 
-WG Meeting
-   Every second Wednesday there is a Working Group meeting.
+PMC Meeting
+   Every second Wednesday there is a PMC meeting.
    To join the meeting check the announcement on `ROS Discourse`_.
-   You can joint the meeting through `google groups <https://groups.google.com/forum/#!forum/ros-control-working-group-invites>`_ or directly on Google Meet (check the announcement).
+   You can joint the meeting through `google groups <https://groups.google.com/forum/#!forum/ros-control-working-group-invites>`_ or directly on Zoom (check the announcement).
    To propose new discussion points, or review notes from previous meetings, check `this document <https://docs.google.com/document/d/1818AoYucI2z82awL_-8sAA5pMCV_g_wXCJiM6SQmhSQ/edit?usp=sharing>`_.
 
 Projects


### PR DESCRIPTION
according to the ros-controls OSRA charter

I took the template from https://docs.ros.org/en/rolling/The-ROS2-Project/Governance.html#id21