### PR TITLE
Remove year of GSoC page

### DIFF
--- a/doc/project_ideas.rst
+++ b/doc/project_ideas.rst
@@ -1,6 +1,6 @@
 .. _project_ideas:
 
-Project Ideas for GSoC 2024
+Project Ideas for GSoC
 =============================
 
 Tutorials and Demos for ros2_control


### PR DESCRIPTION
@bmagyar should we cleanup the list? or even remove the page and collect the ideas somewhere else (as we are now included in the OSRA list)