### PR TITLE
Update getting_started.rst

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -68,6 +68,7 @@ If you want to install the framework from source, e.g., for contributing to the 
     colcon build --symlink-install
 
 * Do not forget to source ``setup.bash`` from the ``install`` folder!
+* If you run into the problem that the ```ros2_control_cmake``` package is missing consider cloning, building and sourcing [this repo](https://github.com/ros-controls/ros2_control_cmake)
 
 
 Architecture


### PR DESCRIPTION
Added a workaround for the fact that under ROS2 Jazzy in Ubuntu 24 LTS ros_control_cmake is not in the package list.