### PR TITLE
Fixed Broken Links in `Differences to ros_control (ROS 1)`

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -154,6 +154,8 @@ Actuator
 
 A detailed explanation of hardware components is given in the `Hardware Access through Controllers design document`_.
 
+.. _hardware_description_in_urdf:
+
 Hardware Description in URDF
 ----------------------------
 The ros2_control framework uses the ``<ros2_control>``-tag in the robot's URDF file to describe its components, i.e., the hardware setup.

--- a/doc/migration/differences_to_ros1.rst
+++ b/doc/migration/differences_to_ros1.rst
@@ -14,7 +14,7 @@ Still, this solution is not optimal, especially when combining robots with exter
 The ros2_control framework defines three types of hardware ``Actuator``, ``Sensor`` and ``System``.
 Using a combination (composition) of those basic components, any physical robotic cell (robot and its surrounding) can be described.
 This also means that multi-robot, robot-sensor, robot-gripper combinations are supported out of the box.
-Section :ref:`Hardware Components section <overview_hardware_components>` describes this in detail.
+Section :ref:`Hardware Components <overview_hardware_components>` describes this in detail.
 
 Hardware Interfaces
 -------------------

--- a/doc/migration/differences_to_ros1.rst
+++ b/doc/migration/differences_to_ros1.rst
@@ -14,14 +14,14 @@ Still, this solution is not optimal, especially when combining robots with exter
 The ros2_control framework defines three types of hardware ``Actuator``, ``Sensor`` and ``System``.
 Using a combination (composition) of those basic components, any physical robotic cell (robot and its surrounding) can be described.
 This also means that multi-robot, robot-sensor, robot-gripper combinations are supported out of the box.
-Section `Hardware Components <#hardware-components>`__ describes this in detail.
+Section :ref:`Hardware Components section <overview_hardware_components>` describes this in detail.
 
 Hardware Interfaces
 -------------------
 
 The ros_control framework allows only three types of interfaces (joints), i.e., ``position``, ``velocity``, and ``effort``. The ``RobotHW`` class makes it very hard to use any other data to control the robot.
 
-The ros2_control approach does not enforce a fixed set of interface types, but they are defined as strings in `hardware's description <#hardware-description-in-urdf>`__.
+The ros2_control approach does not enforce a fixed set of interface types, but they are defined as strings in :ref:`hardware's description <hardware_description_in_urdf>`.
 To ensure compatibility of standard controllers, standard interfaces are defined as constants in `hardware_interface package <https://github.com/ros-controls/ros2_control/blob/master/hardware_interface/include/hardware_interface/types/hardware_interface_type_values.hpp>`__.
 
 Controller's Access to Hardware


### PR DESCRIPTION
## Brief
In this PR
- Fixed Broken Links in `Differences to ros_control (ROS 1)` (refer 2668190dda95ee29c71d51fed39bdafcb54d38c9)
  - Fixes #277

### How was this tested?
Ran `make html` and checked locally at `_build/.......`