### PR TITLE
Fix linkchecker: Ignore Oracle links

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -176,8 +176,7 @@ github_url = "https://github.com/ros-controls/control.ros.org"
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#filtering
 linkcheck_anchors_ignore_for_url = [
     'https://github.com/',
-    'https://index.ros.org/',
-    'https://blogs.oracle.com/'
+    'https://index.ros.org/'
     ]
 linkcheck_ignore = [
     r'https://gazebosim.org/home',

--- a/conf.py
+++ b/conf.py
@@ -176,9 +176,13 @@ github_url = "https://github.com/ros-controls/control.ros.org"
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#filtering
 linkcheck_anchors_ignore_for_url = [
     'https://github.com/',
-    'https://index.ros.org/'
+    'https://index.ros.org/',
+    'https://blogs.oracle.com/'
     ]
-linkcheck_ignore = [r'https://gazebosim.org/home']
+linkcheck_ignore = [
+    r'https://gazebosim.org/home',
+    r'https://blogs.oracle.com/linux/post/task-priority'
+]
 
 # -- Options for HTMLHelp output ---------------------------------------------
 

--- a/make_help_scripts/check_links.py
+++ b/make_help_scripts/check_links.py
@@ -14,9 +14,7 @@
 # limitations under the License.
 
 # This script is used to check the links in the ROS documentation.
-# due to a bug in the sphinx linkchecker, github anchors are false positives and
-# have to be explicitly ignored
-# https://github.com/sphinx-doc/sphinx/issues/9016
+# linkcheck_anchors_ignore_for_url and linkcheck_ignore in conf.py can be used to ignore errors
 
 import os
 import shutil


### PR DESCRIPTION
**Description**
This PR updates the conf.py file to prevent the linkchecker from flagging Oracle links as errors.

**Changes made:**

- Added https://blogs.oracle.com/ to linkcheck_anchors_ignore_for_url.
- Added https://blogs.oracle.com/linux/post/task-priority to linkcheck_ignore.
- Prevents link checker from flagging Oracle links as errors.

**Contribution Guidelines**
Pull requests are much appreciated! Before submitting a PR, please ensure the following:

✅ Limited Scope: PR should focus on a single issue and avoid random fixes.
✅ Descriptive Title: Use a clear title and add a short summary if needed.
✅ Passing Tests: Ensure the pipeline runs successfully.
✅ Request Reviews: Don't hesitate to request reviews from maintainers.
✅ Add Tests: If adding new functionality, include relevant tests.

**Steps to Submit a PR**
 
- [ ] Fork the repository
- [ ]  Modify only the relevant part (avoid unnecessary formatting changes)
- [ ] Ensure local tests pass (colcon test & pre-commit run)
- [ ]  Commit with a clear message
- [ ]  Submit the PR
- [ ]  Monitor CI failures & respond to feedback
