### PR TITLE
Remove the link to rosin project

### DIFF
--- a/doc/acknowledgements/acknowledgements.rst
+++ b/doc/acknowledgements/acknowledgements.rst
@@ -104,7 +104,7 @@ The project has received major contributions from the following companies and in
 |rosin_ack_logo_wide|
 
 Supported by ROSIN - ROS-Industrial Quality-Assured Robot Software Components.
-More information: https://www.rosin-project.eu
+More information: https://cordis.europa.eu/project/id/732287
 
 This project has received funding from the European Union's Horizon 2020
 research and innovation programme under grant agreement no. 732287.


### PR DESCRIPTION
Since a couple of weeks the rosin project page seems to be offline. I changed it to an official EU description page.

`(doc/acknowledgements/acknowledgements: line  106) broken    https://www.rosin-project.eu/ - 502 Server Error: Bad Gateway for url: https://www.rosin-project.eu/`