### PR TITLE
Include realtime_tools and control_toolbox

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -73,9 +73,9 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "README.md",
                     "**/*.md", # exclude markdown files, only add them explicitly
                     "doc/ros2_control/ros2_control/**.rst",
                     "doc/ros2_control/transmission_interface/**.rst",
-                    "doc/realtime_tools/**.rst",
+                    "doc/realtime_tools/realtime_tools/**.rst",
                     "doc/control_msgs/**.rst",
-                    "doc/control_toolbox/**.rst",
+                    "doc/control_toolbox/control_toolbox/**.rst",
                     "doc/kinematics_interface/**.rst",
                     "doc/ros2_controllers/ros2_controllers/**.rst"]
 

--- a/doc/migration/migration.rst
+++ b/doc/migration/migration.rst
@@ -24,3 +24,5 @@ For non-breaking updates, see the :ref:`release_notes`.
 
    ros2_control <../ros2_control/doc/migration.rst>
    ros2_controllers <../ros2_controllers/doc/migration.rst>
+   control_toolbox <../control_toolbox/doc/migration.rst>
+   realtime_tools <../realtime_tools/doc/migration.rst>

--- a/doc/release_notes/release_notes.rst
+++ b/doc/release_notes/release_notes.rst
@@ -15,3 +15,5 @@ For necessary changes to your code for a version update, see the :ref:`migration
 
    ros2_control <../ros2_control/doc/release_notes.rst>
    ros2_controllers <../ros2_controllers/doc/release_notes.rst>
+   control_toolbox <../control_toolbox/doc/release_notes.rst>
+   realtime_tools <../realtime_tools/doc/release_notes.rst>

--- a/doc/utilities.rst
+++ b/doc/utilities.rst
@@ -1,0 +1,11 @@
+Utilities
+--------------------
+
+There exist several utility packages, like command line tools or reusable classes for writing controllers and real-time critical code.
+
+.. toctree::
+   :titlesonly:
+
+   ros2_control/ros2controlcli/doc/userdoc.rst
+   control_toolbox/doc/index.rst
+   realtime_tools/doc/index.rst

--- a/index.rst
+++ b/index.rst
@@ -10,7 +10,7 @@ Welcome to the ros2_control documentation!
    doc/ros2_control/doc/index.rst
    doc/ros2_controllers/doc/controllers_index.rst
    doc/ros2_control_demos/doc/index.rst
-   doc/ros2_control/ros2controlcli/doc/userdoc.rst
+   doc/utilities.rst
    doc/simulators/simulators.rst
    doc/release_notes/release_notes.rst
    doc/migration/migration.rst


### PR DESCRIPTION
I moved the CLI together with the two repos in a category "Utilities"
![image](https://github.com/user-attachments/assets/e792f04c-faf0-4344-ade8-d2172b41f743)

needs 

- https://github.com/ros-controls/realtime_tools/pull/346
- https://github.com/ros-controls/control_toolbox/pull/377
