### PR TITLE
Fix ROS Index link for realtime_tools

### DIFF
--- a/doc/api_list/api_list.rst
+++ b/doc/api_list/api_list.rst
@@ -156,4 +156,4 @@ realtime_tools
      - ROS Index
    * - control_msgs
      - `API <http://docs.ros.org/en/{DISTRO}/p/realtime_tools/>`__
-     - `ROS Index <https://index.ros.org/p/velocity_controllers/>`__
+     - `ROS Index <https://index.ros.org/p/realtime_tools/>`__


### PR DESCRIPTION
Just stumbled upon this. Should be a no-brainer.