### PR TITLE
Include blender.org in the conf.py filter list to resolve linkchecker error

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -178,7 +178,8 @@ github_url = "https://github.com/ros-controls/control.ros.org"
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#filtering
 linkcheck_anchors_ignore_for_url = [
     'https://github.com/',
-    'https://index.ros.org/'
+    'https://index.ros.org/',
+    'https://blender.org/'
     ]
 linkcheck_ignore = [
     r'https://gazebosim.org/home',

--- a/conf.py
+++ b/conf.py
@@ -178,12 +178,12 @@ github_url = "https://github.com/ros-controls/control.ros.org"
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#filtering
 linkcheck_anchors_ignore_for_url = [
     'https://github.com/',
-    'https://index.ros.org/',
-    'https://blender.org/'
+    'https://index.ros.org/'
     ]
 linkcheck_ignore = [
     r'https://gazebosim.org/home',
-    r'https://blogs.oracle.com/linux/post/task-priority'
+    r'https://blogs.oracle.com/linux/post/task-priority',
+    r'https://www.blender.org/'
 ]
 
 # -- Options for HTMLHelp output ---------------------------------------------


### PR DESCRIPTION
This is a follow up to #507.

The [github action log](https://github.com/ros-controls/control.ros.org/actions/runs/17841814350/job/50733431783?pr=507#step:8:7636) shows that linkchecker failed with below message:

(doc/ros2_control_demos/example_7/doc/userdoc: line   64) broken    https://www.blender.org/ - 403 Client Error: Forbidden for url: https://www.blender.org/

This is because ros2_control_demos/example_7 (6-DOF robot) [doc page](https://control.ros.org/rolling/doc/ros2_control_demos/example_7/doc/userdoc.html) includes a reference to blender.org site. As per my understanding the 403 client error happens because blender prevents its site from web-scrapped. 
I am adding https://www.blender.org/ into the filter list in conf.py to resolve the linkchecker error (e.g. linkchecker will not check this link during build).

I have submitted a separate PR to resolve the other errors related to broken links (ros2_controllers doc page).