### PR TITLE
Increase max width

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -1,0 +1,3 @@
+.wy-nav-content {
+    max-width: 64rem;
+}

--- a/conf.py
+++ b/conf.py
@@ -146,6 +146,7 @@ html_static_path = ["_static"]
 # or fully qualified paths (eg. https://...)
 html_css_files = [
     'reviewer_stats.css',
+    'custom.css',
 ]
 
 # Custom sidebar templates, must be a dictionary that maps document names


### PR DESCRIPTION
Closes #592 

Before
<img width="1799" height="1083" alt="Screenshot 2026-03-19 at 06-37-23 Example 1 RRBot — control ros org Mar 2026 documentation" src="https://github.com/user-attachments/assets/ac6b0098-5aaa-4a24-be4c-d116b6ac23c1" />

After 
<img width="1799" height="1083" alt="Screenshot 2026-03-19 at 06-38-28 Example 1 RRBot — control ros org Mar 2026 documentation" src="https://github.com/user-attachments/assets/928098ca-b858-4098-932b-1061a7140e04" />
