### PR TITLE
Fix PR stats

### DIFF
--- a/make_help_scripts/create_pr_stats.py
+++ b/make_help_scripts/create_pr_stats.py
@@ -18,6 +18,47 @@ import os
 from datetime import datetime, timedelta, timezone
 import time
 
+
+GLOBAL_HEADERS = {
+  "Accept": "application/vnd.github.v3+json",
+  "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}"
+}
+REQUEST_TIMEOUT_SECONDS = 30
+
+
+def _get_rate_limit_reset_from_headers(response):
+  """Get reset timestamp from response headers, or 0 when unavailable."""
+  reset_header = response.headers.get("X-RateLimit-Reset")
+  if not reset_header:
+    return 0
+  try:
+    return int(reset_header)
+  except ValueError:
+    return 0
+
+
+def _wait_for_rate_limit_reset(response, default_wait=60):
+  """Sleep until the reported reset time (plus a small safety buffer)."""
+  reset_ts = _get_rate_limit_reset_from_headers(response)
+  if reset_ts > 0:
+    wait_seconds = int(reset_ts - datetime.now(timezone.utc).timestamp()) + 5
+    wait_seconds = max(wait_seconds, 5)
+  else:
+    wait_seconds = default_wait
+  print(f"Rate limit hit, waiting {wait_seconds} seconds before retry")
+  time.sleep(wait_seconds)
+
+
+def _get_retry_after_seconds(response):
+  """Parse Retry-After header if present, otherwise return 0."""
+  retry_after = response.headers.get("Retry-After")
+  if not retry_after:
+    return 0
+  try:
+    return max(int(retry_after), 0)
+  except ValueError:
+    return 0
+
 def get_api_response(url):
   """
   Sends a GET request to the specified URL with the necessary headers and returns the JSON response.
@@ -28,18 +69,74 @@ def get_api_response(url):
   Returns:
     tuple: A tuple containing the JSON response as a dictionary and the response object.
   """
-  global_header = {
-    "Accept": "application/vnd.github.v3+json",
-    "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}"
-  }
-  # TODO(anyone): add error handling
-  response = requests.get(url, headers=global_header)
-  if response.status_code != 200:
-    print(f"Error {response.status_code}: {response.json()['message']}")
-    return [], response
-  json = response.json()
+  max_retries = 4
+  for attempt in range(max_retries + 1):
+    try:
+      response = requests.get(url, headers=GLOBAL_HEADERS, timeout=REQUEST_TIMEOUT_SECONDS)
+    except requests.RequestException as ex:
+      if attempt < max_retries:
+        wait_seconds = min(2 ** attempt, 16)
+        print(f"Request failed ({ex}), retrying in {wait_seconds}s: {url}")
+        time.sleep(wait_seconds)
+        continue
+      print(f"Request failed after retries: {url}")
+      return None, None
 
-  return json, response
+    if response.status_code == 403:
+      try:
+        payload = response.json()
+      except ValueError:
+        payload = {}
+      message = str(payload.get("message", ""))
+      remaining = response.headers.get("X-RateLimit-Remaining", "")
+      is_rate_limit = "rate limit" in message.lower() or remaining == "0"
+      is_secondary_limit = "secondary rate limit" in message.lower()
+      if is_rate_limit or is_secondary_limit:
+        if attempt < max_retries:
+          retry_after = _get_retry_after_seconds(response)
+          if retry_after > 0:
+            print(f"GitHub asked to retry after {retry_after}s")
+            time.sleep(retry_after)
+          else:
+            _wait_for_rate_limit_reset(response)
+          continue
+      print(f"Error {response.status_code}: {message}")
+      return None, response
+
+    if response.status_code == 429:
+      if attempt < max_retries:
+        retry_after = _get_retry_after_seconds(response)
+        wait_seconds = retry_after if retry_after > 0 else min(2 ** attempt, 16)
+        print(f"Too many requests, retrying in {wait_seconds}s")
+        time.sleep(wait_seconds)
+        continue
+      print("Error 429: Too many requests")
+      return None, response
+
+    if response.status_code >= 500:
+      if attempt < max_retries:
+        wait_seconds = min(2 ** attempt, 16)
+        print(f"Server error {response.status_code}, retrying in {wait_seconds}s")
+        time.sleep(wait_seconds)
+        continue
+      print(f"Error {response.status_code}: server error after retries")
+      return None, response
+
+    if response.status_code != 200:
+      try:
+        message = response.json().get("message", "Unknown error")
+      except ValueError:
+        message = response.text
+      print(f"Error {response.status_code}: {message}")
+      return None, response
+
+    try:
+      return response.json(), response
+    except ValueError:
+      print(f"Error: invalid JSON response from {url}")
+      return None, response
+
+  return None, response
 
 def get_api_response_wait(url):
   """
@@ -52,12 +149,7 @@ def get_api_response_wait(url):
   Returns:
     tuple: A tuple containing the JSON response as a dictionary and the response object.
   """
-  remaining, reset = get_api_limit()
-  if remaining == 0:
-    wait_time = datetime.fromtimestamp(reset) - datetime.utcnow()
-    print(f"Waiting {wait_time.total_seconds()} seconds for API rate limit reset")
-    time.sleep(wait_time.total_seconds() + 60) # add 60 seconds to be sure
-
+  # Rate-limit handling is done inside get_api_response with header-based waits.
   return get_api_response(url)
 
 def get_api_limit():
@@ -70,7 +162,7 @@ def get_api_limit():
   url = "https://api.github.com/rate_limit"
   json, response = get_api_response(url)
 
-  if json:
+  if isinstance(json, dict) and "rate" in json:
     return json["rate"]["remaining"], json["rate"]["reset"]
   else:
     return 0, 0
@@ -91,6 +183,9 @@ def get_all_pages(url):
   """
   while url:
     json, response = get_api_response_wait(url)
+
+    if json is None or response is None:
+      break
 
     yield json
 
@@ -114,10 +209,10 @@ def get_user_details(user):
   url = f"https://api.github.com/users/{user}"
   json, _ = get_api_response_wait(url)
 
-  if json:
+  if isinstance(json, dict) and json:
     return json["name"], json["avatar_url"]
   else:
-    return ""
+    return "", ""
 
 
 def get_pr_stats(owner, repos, branches, whitelist, blacklist, earliest_date=""):
@@ -161,6 +256,8 @@ def get_pr_stats(owner, repos, branches, whitelist, blacklist, earliest_date="")
     url = f"https://api.github.com/repos/{owner}/{repo}/pulls?state=closed&base={branches[repo]}&per_page=100"
 
     for pulls in get_all_pages(url):
+      if not isinstance(pulls, list):
+        continue
 
       for pull in pulls:
           ct_pull += 1
@@ -204,6 +301,8 @@ def get_pr_stats(owner, repos, branches, whitelist, blacklist, earliest_date="")
           # Get reviews for the pull request, but count only once per PR
           pull_reviews_url = pull["url"] + "/reviews"
           pull_reviews, _ = get_api_response_wait(pull_reviews_url)
+          if not isinstance(pull_reviews, list):
+            continue
           local_reviewers = {} # prevent double counting
           local_reviewers_filter = {} # prevent double counting
 
@@ -260,6 +359,8 @@ def get_pr_stats(owner, repos, branches, whitelist, blacklist, earliest_date="")
     commits_url = f"https://api.github.com/repos/{owner}/{repo}/commits?branch={branches[repo]}"
 
     for commits in get_all_pages(commits_url):
+      if not isinstance(commits, list):
+        continue
       for commit in commits:
         if commit['author'] is None:
           # print('No author in commit: ' + commit['url'])
@@ -273,6 +374,8 @@ def get_pr_stats(owner, repos, branches, whitelist, blacklist, earliest_date="")
             current_dict = contributors
 
         commit_details, _ = get_api_response_wait(commit['url'])
+        if not isinstance(commit_details, dict):
+          continue
         if 'stats' in commit_details.keys():
           additions = commit_details['stats']['additions']
           deletions = commit_details['stats']['deletions']

--- a/make_help_scripts/create_pr_stats.py
+++ b/make_help_scripts/create_pr_stats.py
@@ -18,47 +18,6 @@ import os
 from datetime import datetime, timedelta, timezone
 import time
 
-
-GLOBAL_HEADERS = {
-  "Accept": "application/vnd.github.v3+json",
-  "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}"
-}
-REQUEST_TIMEOUT_SECONDS = 30
-
-
-def _get_rate_limit_reset_from_headers(response):
-  """Get reset timestamp from response headers, or 0 when unavailable."""
-  reset_header = response.headers.get("X-RateLimit-Reset")
-  if not reset_header:
-    return 0
-  try:
-    return int(reset_header)
-  except ValueError:
-    return 0
-
-
-def _wait_for_rate_limit_reset(response, default_wait=60):
-  """Sleep until the reported reset time (plus a small safety buffer)."""
-  reset_ts = _get_rate_limit_reset_from_headers(response)
-  if reset_ts > 0:
-    wait_seconds = int(reset_ts - datetime.now(timezone.utc).timestamp()) + 5
-    wait_seconds = max(wait_seconds, 5)
-  else:
-    wait_seconds = default_wait
-  print(f"Rate limit hit, waiting {wait_seconds} seconds before retry")
-  time.sleep(wait_seconds)
-
-
-def _get_retry_after_seconds(response):
-  """Parse Retry-After header if present, otherwise return 0."""
-  retry_after = response.headers.get("Retry-After")
-  if not retry_after:
-    return 0
-  try:
-    return max(int(retry_after), 0)
-  except ValueError:
-    return 0
-
 def get_api_response(url):
   """
   Sends a GET request to the specified URL with the necessary headers and returns the JSON response.
@@ -69,75 +28,18 @@ def get_api_response(url):
   Returns:
     tuple: A tuple containing the JSON response as a dictionary and the response object.
   """
-  max_retries = 4
-  for attempt in range(max_retries + 1):
-    try:
-      response = requests.get(url, headers=GLOBAL_HEADERS, timeout=REQUEST_TIMEOUT_SECONDS)
-    except requests.RequestException as ex:
-      if attempt < max_retries:
-        wait_seconds = min(2 ** attempt, 16)
-        print(f"Request failed ({ex}), retrying in {wait_seconds}s: {url}")
-        time.sleep(wait_seconds)
-        continue
-      print(f"Request failed after retries: {url}")
-      return None, None
+  global_header = {
+    "Accept": "application/vnd.github.v3+json",
+    "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}"
+  }
+  # TODO(anyone): add error handling
+  response = requests.get(url, headers=global_header)
+  if response.status_code != 200:
+    print(f"Error {response.status_code}: {response.json()['message']}")
+    return [], response
+  json = response.json()
 
-    # GitHub returns 403 when installation/user rate limit is exceeded.
-    if response.status_code == 403:
-      try:
-        payload = response.json()
-      except ValueError:
-        payload = {}
-      message = str(payload.get("message", ""))
-      remaining = response.headers.get("X-RateLimit-Remaining", "")
-      is_rate_limit = "rate limit" in message.lower() or remaining == "0"
-      is_secondary_limit = "secondary rate limit" in message.lower()
-      if is_rate_limit or is_secondary_limit:
-        if attempt < max_retries:
-          retry_after = _get_retry_after_seconds(response)
-          if retry_after > 0:
-            print(f"GitHub asked to retry after {retry_after}s")
-            time.sleep(retry_after)
-          else:
-            _wait_for_rate_limit_reset(response)
-          continue
-      print(f"Error {response.status_code}: {message}")
-      return None, response
-
-    if response.status_code == 429:
-      if attempt < max_retries:
-        retry_after = _get_retry_after_seconds(response)
-        wait_seconds = retry_after if retry_after > 0 else min(2 ** attempt, 16)
-        print(f"Too many requests, retrying in {wait_seconds}s")
-        time.sleep(wait_seconds)
-        continue
-      print("Error 429: Too many requests")
-      return None, response
-
-    if response.status_code >= 500:
-      if attempt < max_retries:
-        wait_seconds = min(2 ** attempt, 16)
-        print(f"Server error {response.status_code}, retrying in {wait_seconds}s")
-        time.sleep(wait_seconds)
-        continue
-      print(f"Error {response.status_code}: server error after retries")
-      return None, response
-
-    if response.status_code != 200:
-      try:
-        message = response.json().get("message", "Unknown error")
-      except ValueError:
-        message = response.text
-      print(f"Error {response.status_code}: {message}")
-      return None, response
-
-    try:
-      return response.json(), response
-    except ValueError:
-      print(f"Error: invalid JSON response from {url}")
-      return None, response
-
-  return None, response
+  return json, response
 
 def get_api_response_wait(url):
   """
@@ -150,7 +52,12 @@ def get_api_response_wait(url):
   Returns:
     tuple: A tuple containing the JSON response as a dictionary and the response object.
   """
-  # Rate-limit handling is done inside get_api_response with header-based waits.
+  remaining, reset = get_api_limit()
+  if remaining == 0:
+    wait_time = datetime.fromtimestamp(reset) - datetime.utcnow()
+    print(f"Waiting {wait_time.total_seconds()} seconds for API rate limit reset")
+    time.sleep(wait_time.total_seconds() + 60) # add 60 seconds to be sure
+
   return get_api_response(url)
 
 def get_api_limit():
@@ -163,7 +70,7 @@ def get_api_limit():
   url = "https://api.github.com/rate_limit"
   json, response = get_api_response(url)
 
-  if isinstance(json, dict) and "rate" in json:
+  if json:
     return json["rate"]["remaining"], json["rate"]["reset"]
   else:
     return 0, 0
@@ -184,9 +91,6 @@ def get_all_pages(url):
   """
   while url:
     json, response = get_api_response_wait(url)
-
-    if json is None:
-      break
 
     yield json
 
@@ -210,120 +114,10 @@ def get_user_details(user):
   url = f"https://api.github.com/users/{user}"
   json, _ = get_api_response_wait(url)
 
-  if isinstance(json, dict) and json:
+  if json:
     return json["name"], json["avatar_url"]
   else:
-    return "", ""
-
-
-def _merge_contributor_stats(target_dict, login, total_changes, commit_count, date):
-  """Merge per-user contribution stats into a destination dictionary."""
-  if commit_count <= 0:
-    return
-
-  if login in target_dict:
-    target_dict[login]["total_changes"] += total_changes
-    target_dict[login]["ct_commit"] += commit_count
-    if date > target_dict[login]["last_commit_date"]:
-      target_dict[login]["last_commit_date"] = date
-  else:
-    target_dict[login] = {
-      "total_changes": total_changes,
-      "ct_commit": commit_count,
-      "last_commit_date": date
-    }
-
-
-def add_contributors_stats_for_repo(owner, repo, whitelist, blacklist, earliest_date,
-                                   contributors, contributors_whitelist,
-                                   contributors_filter, contributors_filter_whitelist):
-  """
-  Add contributor stats using the low-cost GitHub stats endpoint.
-
-  This endpoint aggregates additions/deletions/commits per week and avoids
-  the very expensive per-commit detail API calls.
-  """
-  stats_url = f"https://api.github.com/repos/{owner}/{repo}/stats/contributors"
-
-  # GitHub can return 202 while generating stats; poll with bounded backoff.
-  stats_data = None
-  max_polls = 10
-  for poll_attempt in range(max_polls):
-    try:
-      response = requests.get(stats_url, headers=GLOBAL_HEADERS, timeout=REQUEST_TIMEOUT_SECONDS)
-    except requests.RequestException as ex:
-      if poll_attempt < max_polls - 1:
-        wait_seconds = min(2 ** poll_attempt, 20)
-        print(f"Contributors stats request failed ({ex}), retrying in {wait_seconds}s")
-        time.sleep(wait_seconds)
-        continue
-      print(f"Contributors stats request failed after retries for {owner}/{repo}")
-      return
-
-    if response.status_code == 202:
-      retry_after = _get_retry_after_seconds(response)
-      wait_seconds = retry_after if retry_after > 0 else min(2 + poll_attempt * 2, 20)
-      if poll_attempt < max_polls - 1:
-        print(f"Contributors stats for {owner}/{repo} are being generated, retrying in {wait_seconds}s")
-        time.sleep(wait_seconds)
-        continue
-      print(f"Contributors stats for {owner}/{repo} still not ready after retries")
-      continue
-
-    if response.status_code == 403:
-      try:
-        message = str(response.json().get("message", ""))
-      except ValueError:
-        message = ""
-      if "rate limit" in message.lower() or response.headers.get("X-RateLimit-Remaining", "") == "0":
-        if poll_attempt < max_polls - 1:
-          retry_after = _get_retry_after_seconds(response)
-          if retry_after > 0:
-            print(f"GitHub asked to retry contributors stats after {retry_after}s")
-            time.sleep(retry_after)
-          else:
-            _wait_for_rate_limit_reset(response)
-          continue
-
-    if response.status_code != 200:
-      try:
-        message = response.json().get("message", "Unknown error")
-      except ValueError:
-        message = response.text
-      print(f"Error {response.status_code} while fetching contributors stats for {owner}/{repo}: {message}")
-      return
-
-    try:
-      stats_data = response.json()
-    except ValueError:
-      print(f"Error: invalid JSON while fetching contributors stats for {owner}/{repo}")
-      return
-    break
-
-  if not isinstance(stats_data, list):
-    print(f"No contributors stats data for {owner}/{repo} (endpoint returned non-list)")
-    return
-
-  for entry in stats_data:
-    author = entry.get("author")
-    if not author:
-      continue
-
-    contributor_login = author.get("login")
-    if not contributor_login or contributor_login in blacklist:
-      continue
-
-    base_dict = contributors_whitelist if contributor_login in whitelist else contributors
-    recent_dict = contributors_filter_whitelist if contributor_login in whitelist else contributors_filter
-
-    for week in entry.get("weeks", []):
-      week_date = datetime.fromtimestamp(week.get("w", 0), tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-      total_changes = int(week.get("a", 0)) + int(week.get("d", 0))
-      commits_in_week = int(week.get("c", 0))
-
-      _merge_contributor_stats(base_dict, contributor_login, total_changes, commits_in_week, week_date)
-      if earliest_date and week_date > earliest_date:
-        _merge_contributor_stats(recent_dict, contributor_login, total_changes, commits_in_week, week_date)
+    return ""
 
 
 def get_pr_stats(owner, repos, branches, whitelist, blacklist, earliest_date=""):
@@ -367,8 +161,6 @@ def get_pr_stats(owner, repos, branches, whitelist, blacklist, earliest_date="")
     url = f"https://api.github.com/repos/{owner}/{repo}/pulls?state=closed&base={branches[repo]}&per_page=100"
 
     for pulls in get_all_pages(url):
-      if not isinstance(pulls, list):
-        continue
 
       for pull in pulls:
           ct_pull += 1
@@ -412,8 +204,6 @@ def get_pr_stats(owner, repos, branches, whitelist, blacklist, earliest_date="")
           # Get reviews for the pull request, but count only once per PR
           pull_reviews_url = pull["url"] + "/reviews"
           pull_reviews, _ = get_api_response_wait(pull_reviews_url)
-          if not isinstance(pull_reviews, list):
-            continue
           local_reviewers = {} # prevent double counting
           local_reviewers_filter = {} # prevent double counting
 
@@ -467,17 +257,57 @@ def get_pr_stats(owner, repos, branches, whitelist, blacklist, earliest_date="")
 
     # parse line contributions from commits
     print(f"Getting contributors' stats for {owner}/{repo} on branch {branches[repo]}")
-    add_contributors_stats_for_repo(
-      owner,
-      repo,
-      whitelist,
-      blacklist,
-      earliest_date,
-      contributors,
-      contributors_whitelist,
-      contributors_filter,
-      contributors_filter_whitelist,
-    )
+    commits_url = f"https://api.github.com/repos/{owner}/{repo}/commits?branch={branches[repo]}"
+
+    for commits in get_all_pages(commits_url):
+      for commit in commits:
+        if commit['author'] is None:
+          # print('No author in commit: ' + commit['url'])
+          continue
+        contributor_login = commit['author']['login']
+        if contributor_login in blacklist:
+            continue
+        if contributor_login in whitelist:
+            current_dict = contributors_whitelist
+        else:
+            current_dict = contributors
+
+        commit_details, _ = get_api_response_wait(commit['url'])
+        if 'stats' in commit_details.keys():
+          additions = commit_details['stats']['additions']
+          deletions = commit_details['stats']['deletions']
+          total_changes = additions + deletions
+        else:
+          # print('No stats in commit details: ' + commit['url'])
+          total_changes = 0
+        date = commit_details['commit']['author']['date']
+        if contributor_login in current_dict:
+          current_dict[contributor_login]["total_changes"] += total_changes
+          current_dict[contributor_login]["ct_commit"] += 1
+          current_dict[contributor_login]["last_commit_date"] = date
+        else:
+          current_dict[contributor_login] = {
+            "total_changes": total_changes,
+            "ct_commit": 1,
+            "last_commit_date": date
+          }
+        # if filter is set, only count reviews after earliest_date
+        if earliest_date and date > earliest_date:
+          if contributor_login in whitelist:
+              current_dict = contributors_filter_whitelist
+          else:
+              current_dict = contributors_filter
+
+          if contributor_login in current_dict:
+            current_dict[contributor_login]["total_changes"] += total_changes
+            current_dict[contributor_login]["ct_commit"] += 1
+            current_dict[contributor_login]["last_commit_date"] = date
+          else:
+            current_dict[contributor_login] = {
+            "total_changes": total_changes,
+            "ct_commit": 1,
+            "last_commit_date": date
+            }
 
   return reviewers, reviewers_whitelist, reviewers_filter, reviewers_filter_whitelist, contributors, contributors_whitelist, contributors_filter, contributors_filter_whitelist, ct_pull
 


### PR DESCRIPTION
GPT 5.3 codex tried to fix it

## Summary

This PR reapplies the API limit and retry resiliency improvements for PR stats collection, while preserving the original contributor statistics behavior.

The previous attempt to improve API handling introduced a behavioral regression in contributor stats by switching to the repository contributors stats endpoint. That endpoint is not branch-scoped and changed the counting semantics.

This change keeps contributor stats on the existing branch-filtered commit path and only ports the safe API/error-handling improvements.

## Problem

The earlier API-limit refactor improved reliability but unintentionally changed contributor statistics:

- Contributor aggregation switched from per-commit branch-filtered data to repository-level weekly aggregates.
- Branch scoping was lost.
- Time filtering became week-bucket based instead of per-commit.

As a result, reported stats no longer matched expected values.

## What Changed

### API request robustness (ported)

- Added shared request configuration:
  - `GLOBAL_HEADERS`
  - `REQUEST_TIMEOUT_SECONDS = 30`
- Added helpers for rate-limit handling:
  - `_get_rate_limit_reset_from_headers`
  - `_wait_for_rate_limit_reset`
  - `_get_retry_after_seconds`
- Reworked `get_api_response` to handle:
  - network/request exceptions with bounded retries and exponential backoff
  - `403` rate-limit/secondary-limit responses
  - `429` retry handling
  - `5xx` retries
  - invalid JSON and non-200 responses safely

### API call-site hardening (ported)

- `get_api_response_wait` now delegates waiting/retry behavior to `get_api_response`.
- Added defensive checks for payload types before iterating:
  - pages (`pulls`, `commits`)
  - reviews payload
  - commit details payload
- `get_api_limit` now validates payload shape (`dict` with `rate`).
- `get_user_details` now safely returns `("", "")` on invalid/missing payloads.

### Behavior intentionally preserved

- Contributor stats remain based on:
  - `commits?branch=<branch>`
  - per-commit details (`stats.additions`, `stats.deletions`)
- No switch to `repos/<owner>/<repo>/stats/contributors`.

## Why This Is Safe

- Reliability improvements are retained for transient failures and API throttling.
- Statistics semantics are unchanged relative to the known-correct implementation.
- Branch-aware contributor accounting is preserved.

## Validation

- Ran syntax validation:
  - `python3 -m py_compile make_help_scripts/create_pr_stats.py`
- Result: success.

## Scope

- Updated file:
  - `make_help_scripts/create_pr_stats.py`
