### PR TITLE
Add stackoverflow to linkcheck_ignore

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -190,6 +190,7 @@ linkcheck_ignore = [
     r'https://gazebosim.org/home',
     r'https://blogs.oracle.com/linux/post/task-priority',
     r'https://www.blender.org/',
+    r'https://stackoverflow.com/.*',
     r'https://en\.cppreference\.com/.*'
 ]
 


### PR DESCRIPTION
```
[2](https://github.com/ros-controls/control.ros.org/actions/runs/32076533587/job/95530853643?pr=696#step:8:9473)
(doc/ros2_control/doc/debugging: line   97) broken    https://stackoverflow.com/questions/10919832/how-to-use-gdb-to-debug-a-plugin - 403 Client Error: Forbidden for url: https://stackoverflow.com/questions/10919832/how-to-use-gdb-to-debug-a-plugin
```