### PR TITLE
docs: list OmniSim ros2_control integration

### DIFF
--- a/doc/simulators/simulators.rst
+++ b/doc/simulators/simulators.rst
@@ -21,5 +21,6 @@ To add your *ros2_control* integration, submit a PR to this page on Github!
 
 * `Isaac Sim <https://moveit.picknik.ai/main/doc/how_to_guides/isaac_panda/isaac_panda_tutorial.html>`__
 * `Webots <https://github.com/cyberbotics/webots_ros2/tree/master/webots_ros2_control>`__
+* `OmniSim <https://github.com/omnilink-tech/omnisim/tree/main/packages/omnisim-ros2>`__
 * `MuJoCo (FZI) <https://github.com/fzi-forschungszentrum-informatik/cartesian_controllers/tree/ros2/cartesian_controller_simulation>`__
 * `Algoryx AGX Dynamic <https://github.com/Algoryx/agx-ros2-collection>`__


### PR DESCRIPTION
Adds OmniSim to the community simulator integrations list. The linked package ships an Apache-2.0 SystemInterface and a one-command Husky diff_drive_controller example. Its documented scope is intentionally narrow: velocity-commanded bases are verified; arm trajectories, Nav2, and MoveIt are not yet demonstrated.