### PR TITLE
Add Duatic DynaArm to the officially supported robots list

### DIFF
--- a/doc/supported_robots/supported_robots.rst
+++ b/doc/supported_robots/supported_robots.rst
@@ -53,6 +53,7 @@ Official (supported by robot manufacturer)
 - `TIAGo - Mobile Manipulator <https://github.com/pal-robotics/tiago_simulation/tree/humble-devel>`_
 - `Universal Robots <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver>`_
 - `xArm <https://github.com/xarm-Developer/xarm_ros2>`_
+- `Duatic DynaArm <https://docs.duatic.com/dynaarm/>`_
 
 Unofficial (from the community)
 --------------------------------


### PR DESCRIPTION

## Description

This PR adds the Duatic DynaArm as officially supported robot to the documentation

The driver repository implementing the ros2control hardware interface as well as the description can be found here:
https://github.com/Duatic/duatic_dynaarm/

The official documentation (to which the link in the documentation points to) can be found here: https://docs.duatic.com/dynaarm/

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

